### PR TITLE
feat(uaa): return "invalid_grant" error when swapping IAM token with …

### DIFF
--- a/bluemix/authentication/authentication_uaa.go
+++ b/bluemix/authentication/authentication_uaa.go
@@ -153,6 +153,8 @@ func (auth *uaaRepository) sendRequest(req *rest.Request, respV interface{}) err
 		if e := json.Unmarshal([]byte(err.Message), &apiErr); e == nil {
 			switch apiErr.ErrorCode {
 			case "":
+			case "invalid_grant":
+				return NewInvalidGrantTypeError(apiErr.Description)
 			case "invalid-token":
 				return NewInvalidTokenError(apiErr.Description)
 			default:

--- a/bluemix/authentication/errors.go
+++ b/bluemix/authentication/errors.go
@@ -34,3 +34,15 @@ func NewServerError(statusCode int, errorCode string, description string) *Serve
 		Description: description,
 	}
 }
+
+type InvalidGrantTypeError struct {
+	Description string
+}
+
+func NewInvalidGrantTypeError(descrption string) *InvalidGrantTypeError {
+	return &InvalidGrantTypeError{Description: descrption}
+}
+
+func (e *InvalidGrantTypeError) Error() string {
+	return T("Invalid grant type: ") + e.Description
+}


### PR DESCRIPTION
…UAA token

This is the prerequisite to handle IAM token expiry when swapping IAM token with UAA token. "invalid_grant" error will be returned if IAM token has expired. The client can check the error type to handle that error in a different way (e.g. renew IAM token using refresh token).