### PR TITLE
Add support for a IBMCLOUD_CONFIG_HOME which is the absolute path to the config dir

### DIFF
--- a/bluemix/configuration/config_helpers/helpers.go
+++ b/bluemix/configuration/config_helpers/helpers.go
@@ -37,6 +37,13 @@ func ConfigDir() string {
 
 func newConfigDir() string {
 	if configDir := bluemix.EnvConfigDir.Get(); configDir != "" {
+		if !file_helpers.FileExists(configDir) {
+			err := os.MkdirAll(configDir, 0777)
+			if err != nil {
+				// if the directory did not exist and could not be created, use the default
+				return filepath.Join(homeDir(), ".ibmcloud")
+			}
+		}
 		return configDir
 	}
 	return filepath.Join(homeDir(), ".ibmcloud")

--- a/bluemix/configuration/config_helpers/helpers.go
+++ b/bluemix/configuration/config_helpers/helpers.go
@@ -36,6 +36,9 @@ func ConfigDir() string {
 // }
 
 func newConfigDir() string {
+	if configDir := bluemix.EnvConfigDir.Get(); configDir != "" {
+		return configDir
+	}
 	return filepath.Join(homeDir(), ".ibmcloud")
 }
 

--- a/bluemix/env.go
+++ b/bluemix/env.go
@@ -12,6 +12,7 @@ var (
 	EnvHTTPTimeout  = newEnv("IBMCLOUD_HTTP_TIMEOUT", "BLUEMIX_HTTP_TIMEOUT")
 	EnvAPIKey       = newEnv("IBMCLOUD_API_KEY", "BLUEMIX_API_KEY")
 	EnvConfigHome   = newEnv("IBMCLOUD_HOME", "BLUEMIX_HOME")
+	EnvConfigDir    = newEnv("IBMCLOUD_CONFIG_HOME")
 
 	// for internal use
 	EnvCLIName         = newEnv("IBMCLOUD_CLI", "BLUEMIX_CLI")


### PR DESCRIPTION
In preparation to align IBM Cloud CLI and private cloud CLI.