### PR TITLE
feat(crn): add support for "global" scope

### DIFF
--- a/bluemix/crn/crn.go
+++ b/bluemix/crn/crn.go
@@ -31,10 +31,11 @@ const (
 	ScopeSpace        = "s"
 	ScopeProject      = "p"
 
-	ResourceTypeCFSpace   = "cf-space"
-	ResourceTypeCFApp     = "cf-application"
-	ResourceTypeCFService = "cf-service-instance"
-	ResourceTypeRole      = "role"
+	ResourceTypeCFSpace    = "cf-space"
+	ResourceTypeCFApp      = "cf-application"
+	ResourceTypeCFService  = "cf-service-instance"
+	ResourceTypeRole       = "role"
+	ResourceTypeDeployment = "deployment"
 	// more resources ...
 )
 
@@ -101,10 +102,13 @@ func Parse(s string) (CRN, error) {
 	scopeSegments := segments[6]
 	if scopeSegments != "" {
 		scopeParts := strings.Split(scopeSegments, scopeSeparator)
-		if len(scopeParts) != 2 {
+		if len(scopeParts) == 2 {
+			crn.ScopeType, crn.Scope = scopeParts[0], scopeParts[1]
+		} else if scopeSegments == "global" {
+			crn.Scope = "global"
+		} else {
 			return CRN{}, ErrMalformedScope
 		}
-		crn.ScopeType, crn.Scope = scopeParts[0], scopeParts[1]
 	}
 
 	return crn, nil
@@ -126,8 +130,13 @@ func (c CRN) String() string {
 }
 
 func (c CRN) ScopeSegment() string {
-	if c.ScopeType == "" && c.Scope == "" {
-		return ""
+	if c.ScopeType == "" {
+		switch c.Scope {
+		case "":
+			return ""
+		case "global":
+			return "global"
+		}
 	}
 	return c.ScopeType + scopeSeparator + c.Scope
 }

--- a/bluemix/crn/crn_test.go
+++ b/bluemix/crn/crn_test.go
@@ -1,0 +1,43 @@
+package crn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type CRNTestSuite struct {
+	suite.Suite
+}
+
+func TestCRNSuite(t *testing.T) {
+	suite.Run(t, new(CRNTestSuite))
+}
+
+func (suite *CRNTestSuite) TestParse() {
+	crnString := "crn:v1:bluemix:public:test-service::a/account-guid::deployment:deployment-guid"
+	crn, err := Parse(crnString)
+	suite.NoError(err)
+	suite.Equal("test-service", crn.ServiceName)
+	suite.Equal("", crn.Region)
+	suite.Equal(ScopeAccount, crn.ScopeType)
+	suite.Equal("account-guid", crn.Scope)
+	suite.Equal("a/account-guid", crn.ScopeSegment())
+	suite.Equal(ResourceTypeDeployment, crn.ResourceType)
+	suite.Equal("deployment-guid", crn.Resource)
+
+	crnString = "crn:v1:bluemix:public:test-service:us-south:global::deployment:deployment-guid"
+	crn, err = Parse(crnString)
+	suite.NoError(err)
+	suite.Equal("test-service", crn.ServiceName)
+	suite.Equal("us-south", crn.Region)
+	suite.Equal("", crn.ScopeType)
+	suite.Equal("global", crn.Scope)
+	suite.Equal("global", crn.ScopeSegment())
+	suite.Equal(ResourceTypeDeployment, crn.ResourceType)
+	suite.Equal("deployment-guid", crn.Resource)
+
+	crnString = "crn:v1:bluemix:public:test-service:us-south:error::deployment:deployment-guid"
+	_, err = Parse(crnString)
+	suite.Error(err)
+}


### PR DESCRIPTION
The scope segment now has a new value "global". This commit:
1. Add parsing support of "global" scope
2. Add corresponding unit test

close #142