### PR TITLE
feat(crn): add new service name values `cf` and `cfaas`

### DIFF
--- a/bluemix/crn/crn.go
+++ b/bluemix/crn/crn.go
@@ -24,6 +24,10 @@ var (
 const (
 	ServiceBluemix = "bluemix"
 	ServiceIAM     = "iam"
+	// ServiceCF is the service name for public Cloudfoundry
+	ServiceCF = "cf"
+	// ServiceCFEE is the service name for CFEE Cloudfoundry
+	ServiceCFEE = "cfaas"
 	// more services ...
 
 	ScopeAccount      = "a"


### PR DESCRIPTION
`cf` is the service name for public Cloudfoundry, and `cfaas` is the service name for CFEE Cloudfoundry.