### PR TITLE
feat(iam): add service id support in iam token

### DIFF
--- a/bluemix/configuration/core_config/bx_config.go
+++ b/bluemix/configuration/core_config/bx_config.go
@@ -221,7 +221,7 @@ func (c *bxConfig) IAMRefreshToken() (token string) {
 
 func (c *bxConfig) UserEmail() (email string) {
 	c.read(func() {
-		email = NewIAMTokenInfo(c.data.IAMToken).UserEmail
+		email = NewIAMTokenInfo(c.data.IAMToken).Subject
 	})
 	return
 }

--- a/bluemix/configuration/core_config/iam_token.go
+++ b/bluemix/configuration/core_config/iam_token.go
@@ -7,6 +7,12 @@ import (
 	"time"
 )
 
+const (
+	// IAM Token Subject Types
+	// ServiceIDSubjectType is the subject type for service ID
+	ServiceIDSubjectType = "ServiceId"
+)
+
 type IAMTokenInfo struct {
 	IAMID       string       `json:"iam_id"`
 	ID          string       `json:"id"`


### PR DESCRIPTION
1. add a new constant `ServiceIDSubjectType` which represents the subject type for service ID in IAM token
2. return `subject` property of IAM token in `UserEmail()` function, which is supposed to support wider range of subjects