### PR TITLE
feat(sdk): add `UserDisplayText()` to ibm cloud core config

### DIFF
--- a/bluemix/configuration/core_config/bx_config.go
+++ b/bluemix/configuration/core_config/bx_config.go
@@ -226,6 +226,18 @@ func (c *bxConfig) UserEmail() (email string) {
 	return
 }
 
+func (c *bxConfig) UserDisplayText() (text string) {
+	c.read(func() {
+		token := NewIAMTokenInfo(c.data.IAMToken)
+		if token.UserEmail != "" {
+			text = token.UserEmail
+		} else {
+			text = token.Subject
+		}
+	})
+	return
+}
+
 func (c *bxConfig) IAMID() (guid string) {
 	c.read(func() {
 		guid = NewIAMTokenInfo(c.data.IAMToken).IAMID

--- a/bluemix/configuration/core_config/repository.go
+++ b/bluemix/configuration/core_config/repository.go
@@ -23,6 +23,8 @@ type Repository interface {
 	IAMRefreshToken() string
 	IsLoggedIn() bool
 	UserEmail() string
+	// UserDisplayText is the human readable ID for logged-in users which include non-human IDs
+	UserDisplayText() string
 	IAMID() string
 	CurrentAccount() models.Account
 	HasTargetedAccount() bool


### PR DESCRIPTION
Since there are other types of logged-in *users*, email is not capable of being a human  readable ID
to display on console. This commit will add a new method `UserDisplayText()` to core config, to support more types of logged in users.