### PR TITLE
feat(config): add `UsageStatsLastUpdate`

### DIFF
--- a/bluemix/configuration/core_config/bx_config.go
+++ b/bluemix/configuration/core_config/bx_config.go
@@ -47,6 +47,7 @@ type BXConfigData struct {
 	CheckCLIVersionDisabled    bool
 	UsageStatsDisabled         bool // deprecated: use UsageStatsEnabled
 	UsageStatsEnabled          bool
+	UsageStatsLastUpdate       time.Time
 	SDKVersion                 string
 	UpdateCheckInterval        time.Duration
 	UpdateRetryCheckInterval   time.Duration
@@ -384,6 +385,20 @@ func (c *bxConfig) UsageStatsEnabled() (enabled bool) {
 	return
 }
 
+func (c *bxConfig) UsageStatsLastUpdate() (lastUpdate time.Time) {
+	c.read(func() {
+		lastUpdate = c.data.UsageStatsLastUpdate
+	})
+	return
+}
+
+func (c *bxConfig) UsageStatsAllowed() (allowed bool) {
+	c.read(func() {
+		allowed = !c.data.UsageStatsLastUpdate.IsZero() && c.data.UsageStatsEnabled
+	})
+	return
+}
+
 func (c *bxConfig) SDKVersion() (version string) {
 	c.read(func() {
 		version = c.data.SDKVersion
@@ -533,6 +548,7 @@ func (c *bxConfig) SetUsageStatsDisabled(disabled bool) {
 func (c *bxConfig) SetUsageStatsEnabled(enabled bool) {
 	c.write(func() {
 		c.data.UsageStatsEnabled = enabled
+		c.data.UsageStatsLastUpdate = time.Now()
 	})
 }
 

--- a/bluemix/configuration/core_config/bx_config.go
+++ b/bluemix/configuration/core_config/bx_config.go
@@ -23,36 +23,36 @@ func (r raw) Unmarshal(bytes []byte) error {
 }
 
 type BXConfigData struct {
-	APIEndpoint                string
-	ConsoleEndpoint            string
-	CloudType                  string
-	CloudName                  string
-	Region                     string
-	RegionID                   string
-	IAMEndpoint                string
-	IAMToken                   string
-	IAMRefreshToken            string
-	Account                    models.Account
-	ResourceGroup              models.ResourceGroup
-	LoginAt                    time.Time
-	CFEETargeted               bool
-	CFEEEnvID                  string
-	PluginRepos                []models.PluginRepo
-	SSLDisabled                bool
-	Locale                     string
-	Trace                      string
-	ColorEnabled               string
-	HTTPTimeout                int
-	CLIInfoEndpoint            string
-	CheckCLIVersionDisabled    bool
-	UsageStatsDisabled         bool // deprecated: use UsageStatsEnabled
-	UsageStatsEnabled          bool
-	UsageStatsLastUpdate       time.Time
-	SDKVersion                 string
-	UpdateCheckInterval        time.Duration
-	UpdateRetryCheckInterval   time.Duration
-	UpdateNotificationInterval time.Duration
-	raw                        raw
+	APIEndpoint                 string
+	ConsoleEndpoint             string
+	CloudType                   string
+	CloudName                   string
+	Region                      string
+	RegionID                    string
+	IAMEndpoint                 string
+	IAMToken                    string
+	IAMRefreshToken             string
+	Account                     models.Account
+	ResourceGroup               models.ResourceGroup
+	LoginAt                     time.Time
+	CFEETargeted                bool
+	CFEEEnvID                   string
+	PluginRepos                 []models.PluginRepo
+	SSLDisabled                 bool
+	Locale                      string
+	Trace                       string
+	ColorEnabled                string
+	HTTPTimeout                 int
+	CLIInfoEndpoint             string
+	CheckCLIVersionDisabled     bool
+	UsageStatsDisabled          bool // deprecated: use UsageStatsEnabled
+	UsageStatsEnabled           bool
+	UsageStatsEnabledLastUpdate time.Time
+	SDKVersion                  string
+	UpdateCheckInterval         time.Duration
+	UpdateRetryCheckInterval    time.Duration
+	UpdateNotificationInterval  time.Duration
+	raw                         raw
 }
 
 func NewBXConfigData() *BXConfigData {
@@ -380,21 +380,14 @@ func (c *bxConfig) UsageStatsDisabled() (disabled bool) {
 
 func (c *bxConfig) UsageStatsEnabled() (enabled bool) {
 	c.read(func() {
-		enabled = c.data.UsageStatsEnabled
+		enabled = !c.data.UsageStatsEnabledLastUpdate.IsZero() && c.data.UsageStatsEnabled
 	})
 	return
 }
 
-func (c *bxConfig) UsageStatsLastUpdate() (lastUpdate time.Time) {
+func (c *bxConfig) UsageStatsEnabledLastUpdate() (lastUpdate time.Time) {
 	c.read(func() {
-		lastUpdate = c.data.UsageStatsLastUpdate
-	})
-	return
-}
-
-func (c *bxConfig) UsageStatsAllowed() (allowed bool) {
-	c.read(func() {
-		allowed = !c.data.UsageStatsLastUpdate.IsZero() && c.data.UsageStatsEnabled
+		lastUpdate = c.data.UsageStatsEnabledLastUpdate
 	})
 	return
 }
@@ -548,7 +541,7 @@ func (c *bxConfig) SetUsageStatsDisabled(disabled bool) {
 func (c *bxConfig) SetUsageStatsEnabled(enabled bool) {
 	c.write(func() {
 		c.data.UsageStatsEnabled = enabled
-		c.data.UsageStatsLastUpdate = time.Now()
+		c.data.UsageStatsEnabledLastUpdate = time.Now()
 	})
 }
 

--- a/bluemix/configuration/core_config/bx_config_test.go
+++ b/bluemix/configuration/core_config/bx_config_test.go
@@ -1,0 +1,191 @@
+package core_config_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/configuration/core_config"
+	"github.com/stretchr/testify/assert"
+)
+
+// test case 1: no last updated, no enabled
+func TestNoLastUpdateAndNoEnabled(t *testing.T) {
+	config := prepareConfigForCLI("", t)
+
+	// check
+	checkUsageStats(false, false, false, config, t)
+
+	// enabled
+	config.SetUsageStatsEnabled(true)
+	checkUsageStats(true, true, true, config, t)
+
+	// disabled
+	config.SetUsageStatsEnabled(false)
+	checkUsageStats(false, true, false, config, t)
+
+	t.Cleanup(cleanupConfigFiles)
+}
+
+// test case 2: no last updated, enabled false
+func TestNoLastUpdateAndDisabled(t *testing.T) {
+	config := prepareConfigForCLI(`{"UsageStatsEnabled": false}`, t)
+
+	// check
+	checkUsageStats(false, false, false, config, t)
+
+	// enabled
+	config.SetUsageStatsEnabled(true)
+	checkUsageStats(true, true, true, config, t)
+
+	// disabled
+	config.SetUsageStatsEnabled(false)
+	checkUsageStats(false, true, false, config, t)
+
+	t.Cleanup(cleanupConfigFiles)
+}
+
+// test case 3: no last updated, enabled true
+func TestNoLastUpdateAndEnabled(t *testing.T) {
+	config := prepareConfigForCLI(`{"UsageStatsEnabled": true}`, t)
+
+	// check
+	checkUsageStats(true, false, false, config, t)
+
+	// write enabled
+	config.SetUsageStatsEnabled(true)
+	checkUsageStats(true, true, true, config, t)
+
+	// disabled
+	config.SetUsageStatsEnabled(false)
+	checkUsageStats(false, true, false, config, t)
+
+	t.Cleanup(cleanupConfigFiles)
+}
+
+// test case 4: zero update, no enabled
+func TestZeroLastUpdateAndNoEnabled(t *testing.T) {
+	config := prepareConfigForCLI(`{"UsageStatsLastUpdate": "0001-01-01T00:00:00Z"}`, t)
+
+	// check
+	checkUsageStats(false, false, false, config, t)
+
+	// enabled
+	config.SetUsageStatsEnabled(true)
+	checkUsageStats(true, true, true, config, t)
+
+	// disabled
+	config.SetUsageStatsEnabled(false)
+	checkUsageStats(false, true, false, config, t)
+
+	t.Cleanup(cleanupConfigFiles)
+}
+
+// test case 5: zero updated, enabled false
+func TestZeroLastUpdateAndDisabled(t *testing.T) {
+	config := prepareConfigForCLI(`{"UsageStatsLastUpdate": "0001-01-01T00:00:00Z","UsageStatsEnabled": false}`, t)
+
+	// check
+	checkUsageStats(false, false, false, config, t)
+
+	// enabled
+	config.SetUsageStatsEnabled(true)
+	checkUsageStats(true, true, true, config, t)
+
+	// disabled
+	config.SetUsageStatsEnabled(false)
+	checkUsageStats(false, true, false, config, t)
+
+	t.Cleanup(cleanupConfigFiles)
+}
+
+// test case 6: zero updated, enabled true
+func TestZeroLastUpdateAndEnabled(t *testing.T) {
+	config := prepareConfigForCLI(`{"UsageStatsLastUpdate": "0001-01-01T00:00:00Z","UsageStatsEnabled": true}`, t)
+
+	// check
+	checkUsageStats(true, false, false, config, t)
+
+	// enabled
+	config.SetUsageStatsEnabled(true)
+	checkUsageStats(true, true, true, config, t)
+
+	// disabled
+	config.SetUsageStatsEnabled(false)
+	checkUsageStats(false, true, false, config, t)
+
+	t.Cleanup(cleanupConfigFiles)
+}
+
+// test case 7: updated, no enabled
+func TestLastUpdateAndNoEnabled(t *testing.T) {
+	config := prepareConfigForCLI(`{"UsageStatsLastUpdate": "2020-03-29T12:23:43.519017+08:00"}`, t)
+
+	// check
+	checkUsageStats(false, true, false, config, t)
+
+	// enabled
+	config.SetUsageStatsEnabled(true)
+	checkUsageStats(true, true, true, config, t)
+
+	// disabled
+	config.SetUsageStatsEnabled(false)
+	checkUsageStats(false, true, false, config, t)
+
+	t.Cleanup(cleanupConfigFiles)
+}
+
+// test case 8: updated, enabled false
+func TestLastUpdateAndDisabled(t *testing.T) {
+	config := prepareConfigForCLI(`{"UsageStatsLastUpdate": "2020-03-29T12:23:43.519017+08:00","UsageStatsEnabled": false}`, t)
+
+	// check
+	checkUsageStats(false, true, false, config, t)
+
+	// enabled
+	config.SetUsageStatsEnabled(true)
+	checkUsageStats(true, true, true, config, t)
+
+	// disabled
+	config.SetUsageStatsEnabled(false)
+	checkUsageStats(false, true, false, config, t)
+
+	t.Cleanup(cleanupConfigFiles)
+}
+
+// test case 9: updated, enabled true
+func TestLastUpdateAndEnabled(t *testing.T) {
+	config := prepareConfigForCLI(`{"UsageStatsLastUpdate": "2020-03-29T12:23:43.519017+08:00","UsageStatsEnabled": true}`, t)
+
+	// check
+	checkUsageStats(true, true, true, config, t)
+
+	// disable
+	config.SetUsageStatsEnabled(false)
+	checkUsageStats(false, true, false, config, t)
+
+	// enable
+	config.SetUsageStatsEnabled(true)
+	checkUsageStats(true, true, true, config, t)
+
+	t.Cleanup(cleanupConfigFiles)
+}
+
+func checkUsageStats(enabled bool, timeStampExist bool, allowed bool, config core_config.Repository, t *testing.T) {
+	assert.Equal(t, config.UsageStatsEnabled(), enabled)
+	assert.Equal(t, config.UsageStatsLastUpdate().IsZero(), !timeStampExist)
+	assert.Equal(t, config.UsageStatsAllowed(), allowed)
+}
+
+func prepareConfigForCLI(cliConfigContent string, t *testing.T) core_config.Repository {
+	ioutil.WriteFile("config.json", []byte(cliConfigContent), 0644)
+	ioutil.WriteFile("cf_config.json", []byte(""), 0644)
+	return core_config.NewCoreConfigFromPath("cf_config.json", "config.json", func(err error) {
+		t.Fatal(err.Error())
+	})
+}
+
+func cleanupConfigFiles() {
+	os.Remove("config.json")
+	os.Remove("cf_config.json")
+}

--- a/bluemix/configuration/core_config/bx_config_test.go
+++ b/bluemix/configuration/core_config/bx_config_test.go
@@ -14,15 +14,15 @@ func TestNoLastUpdateAndNoEnabled(t *testing.T) {
 	config := prepareConfigForCLI("", t)
 
 	// check
-	checkUsageStats(false, false, false, config, t)
+	checkUsageStats(false, false, config, t)
 
 	// enabled
 	config.SetUsageStatsEnabled(true)
-	checkUsageStats(true, true, true, config, t)
+	checkUsageStats(true, true, config, t)
 
 	// disabled
 	config.SetUsageStatsEnabled(false)
-	checkUsageStats(false, true, false, config, t)
+	checkUsageStats(false, true, config, t)
 
 	t.Cleanup(cleanupConfigFiles)
 }
@@ -32,15 +32,15 @@ func TestNoLastUpdateAndDisabled(t *testing.T) {
 	config := prepareConfigForCLI(`{"UsageStatsEnabled": false}`, t)
 
 	// check
-	checkUsageStats(false, false, false, config, t)
+	checkUsageStats(false, false, config, t)
 
 	// enabled
 	config.SetUsageStatsEnabled(true)
-	checkUsageStats(true, true, true, config, t)
+	checkUsageStats(true, true, config, t)
 
 	// disabled
 	config.SetUsageStatsEnabled(false)
-	checkUsageStats(false, true, false, config, t)
+	checkUsageStats(false, true, config, t)
 
 	t.Cleanup(cleanupConfigFiles)
 }
@@ -50,131 +50,130 @@ func TestNoLastUpdateAndEnabled(t *testing.T) {
 	config := prepareConfigForCLI(`{"UsageStatsEnabled": true}`, t)
 
 	// check
-	checkUsageStats(true, false, false, config, t)
+	checkUsageStats(false, false, config, t)
 
 	// write enabled
 	config.SetUsageStatsEnabled(true)
-	checkUsageStats(true, true, true, config, t)
+	checkUsageStats(true, true, config, t)
 
 	// disabled
 	config.SetUsageStatsEnabled(false)
-	checkUsageStats(false, true, false, config, t)
+	checkUsageStats(false, true, config, t)
 
 	t.Cleanup(cleanupConfigFiles)
 }
 
 // test case 4: zero update, no enabled
 func TestZeroLastUpdateAndNoEnabled(t *testing.T) {
-	config := prepareConfigForCLI(`{"UsageStatsLastUpdate": "0001-01-01T00:00:00Z"}`, t)
+	config := prepareConfigForCLI(`{"UsageStatsEnabledLastUpdate": "0001-01-01T00:00:00Z"}`, t)
 
 	// check
-	checkUsageStats(false, false, false, config, t)
+	checkUsageStats(false, false, config, t)
 
 	// enabled
 	config.SetUsageStatsEnabled(true)
-	checkUsageStats(true, true, true, config, t)
+	checkUsageStats(true, true, config, t)
 
 	// disabled
 	config.SetUsageStatsEnabled(false)
-	checkUsageStats(false, true, false, config, t)
+	checkUsageStats(false, true, config, t)
 
 	t.Cleanup(cleanupConfigFiles)
 }
 
 // test case 5: zero updated, enabled false
 func TestZeroLastUpdateAndDisabled(t *testing.T) {
-	config := prepareConfigForCLI(`{"UsageStatsLastUpdate": "0001-01-01T00:00:00Z","UsageStatsEnabled": false}`, t)
+	config := prepareConfigForCLI(`{"UsageStatsEnabledLastUpdate": "0001-01-01T00:00:00Z","UsageStatsEnabled": false}`, t)
 
 	// check
-	checkUsageStats(false, false, false, config, t)
+	checkUsageStats(false, false, config, t)
 
 	// enabled
 	config.SetUsageStatsEnabled(true)
-	checkUsageStats(true, true, true, config, t)
+	checkUsageStats(true, true, config, t)
 
 	// disabled
 	config.SetUsageStatsEnabled(false)
-	checkUsageStats(false, true, false, config, t)
+	checkUsageStats(false, true, config, t)
 
 	t.Cleanup(cleanupConfigFiles)
 }
 
 // test case 6: zero updated, enabled true
 func TestZeroLastUpdateAndEnabled(t *testing.T) {
-	config := prepareConfigForCLI(`{"UsageStatsLastUpdate": "0001-01-01T00:00:00Z","UsageStatsEnabled": true}`, t)
+	config := prepareConfigForCLI(`{"UsageStatsEnabledLastUpdate": "0001-01-01T00:00:00Z","UsageStatsEnabled": true}`, t)
 
 	// check
-	checkUsageStats(true, false, false, config, t)
+	checkUsageStats(false, false, config, t)
 
 	// enabled
 	config.SetUsageStatsEnabled(true)
-	checkUsageStats(true, true, true, config, t)
+	checkUsageStats(true, true, config, t)
 
 	// disabled
 	config.SetUsageStatsEnabled(false)
-	checkUsageStats(false, true, false, config, t)
+	checkUsageStats(false, true, config, t)
 
 	t.Cleanup(cleanupConfigFiles)
 }
 
 // test case 7: updated, no enabled
 func TestLastUpdateAndNoEnabled(t *testing.T) {
-	config := prepareConfigForCLI(`{"UsageStatsLastUpdate": "2020-03-29T12:23:43.519017+08:00"}`, t)
+	config := prepareConfigForCLI(`{"UsageStatsEnabledLastUpdate": "2020-03-29T12:23:43.519017+08:00"}`, t)
 
 	// check
-	checkUsageStats(false, true, false, config, t)
+	checkUsageStats(false, true, config, t)
 
 	// enabled
 	config.SetUsageStatsEnabled(true)
-	checkUsageStats(true, true, true, config, t)
+	checkUsageStats(true, true, config, t)
 
 	// disabled
 	config.SetUsageStatsEnabled(false)
-	checkUsageStats(false, true, false, config, t)
+	checkUsageStats(false, true, config, t)
 
 	t.Cleanup(cleanupConfigFiles)
 }
 
 // test case 8: updated, enabled false
 func TestLastUpdateAndDisabled(t *testing.T) {
-	config := prepareConfigForCLI(`{"UsageStatsLastUpdate": "2020-03-29T12:23:43.519017+08:00","UsageStatsEnabled": false}`, t)
+	config := prepareConfigForCLI(`{"UsageStatsEnabledLastUpdate": "2020-03-29T12:23:43.519017+08:00","UsageStatsEnabled": false}`, t)
 
 	// check
-	checkUsageStats(false, true, false, config, t)
+	checkUsageStats(false, true, config, t)
 
 	// enabled
 	config.SetUsageStatsEnabled(true)
-	checkUsageStats(true, true, true, config, t)
+	checkUsageStats(true, true, config, t)
 
 	// disabled
 	config.SetUsageStatsEnabled(false)
-	checkUsageStats(false, true, false, config, t)
+	checkUsageStats(false, true, config, t)
 
 	t.Cleanup(cleanupConfigFiles)
 }
 
 // test case 9: updated, enabled true
 func TestLastUpdateAndEnabled(t *testing.T) {
-	config := prepareConfigForCLI(`{"UsageStatsLastUpdate": "2020-03-29T12:23:43.519017+08:00","UsageStatsEnabled": true}`, t)
+	config := prepareConfigForCLI(`{"UsageStatsEnabledLastUpdate": "2020-03-29T12:23:43.519017+08:00","UsageStatsEnabled": true}`, t)
 
 	// check
-	checkUsageStats(true, true, true, config, t)
+	checkUsageStats(true, true, config, t)
 
 	// disable
 	config.SetUsageStatsEnabled(false)
-	checkUsageStats(false, true, false, config, t)
+	checkUsageStats(false, true, config, t)
 
 	// enable
 	config.SetUsageStatsEnabled(true)
-	checkUsageStats(true, true, true, config, t)
+	checkUsageStats(true, true, config, t)
 
 	t.Cleanup(cleanupConfigFiles)
 }
 
-func checkUsageStats(enabled bool, timeStampExist bool, allowed bool, config core_config.Repository, t *testing.T) {
+func checkUsageStats(enabled bool, timeStampExist bool, config core_config.Repository, t *testing.T) {
 	assert.Equal(t, config.UsageStatsEnabled(), enabled)
-	assert.Equal(t, config.UsageStatsLastUpdate().IsZero(), !timeStampExist)
-	assert.Equal(t, config.UsageStatsAllowed(), allowed)
+	assert.Equal(t, config.UsageStatsEnabledLastUpdate().IsZero(), !timeStampExist)
 }
 
 func prepareConfigForCLI(cliConfigContent string, t *testing.T) core_config.Repository {

--- a/bluemix/configuration/core_config/repository.go
+++ b/bluemix/configuration/core_config/repository.go
@@ -47,10 +47,8 @@ type Repository interface {
 	UsageStatsDisabled() bool
 	// UsageSatsEnabled returns whether the usage statistics data collection is enabled or not
 	UsageStatsEnabled() bool
-	// UsageStatsLastUpdate returns last time when `UsageStatsEnabled` was updated
-	UsageStatsLastUpdate() time.Time
-	// UsageStatsAllowed will return whether the user agree to collect usage statistic
-	UsageStatsAllowed() bool
+	// UsageStatsEnabledLastUpdate returns last time when `UsageStatsEnabled` was updated
+	UsageStatsEnabledLastUpdate() time.Time
 	Locale() string
 	LoginAt() time.Time
 	Trace() string

--- a/bluemix/configuration/core_config/repository.go
+++ b/bluemix/configuration/core_config/repository.go
@@ -47,6 +47,10 @@ type Repository interface {
 	UsageStatsDisabled() bool
 	// UsageSatsEnabled returns whether the usage statistics data collection is enabled or not
 	UsageStatsEnabled() bool
+	// UsageStatsLastUpdate returns last time when `UsageStatsEnabled` was updated
+	UsageStatsLastUpdate() time.Time
+	// UsageStatsAllowed will return whether the user agree to collect usage statistic
+	UsageStatsAllowed() bool
 	Locale() string
 	LoginAt() time.Time
 	Trace() string


### PR DESCRIPTION
1. add property `UsageStatsLastUpdate` in `bxConfig`
2. add reader `UsageStatsLastUpdate` in `Repository`, which can be used to decided last time user has changed `UsageStatsEnabled`
3. add reader `UsageStatsAllowed` in `Repository`, which indicates whether it's allowed to collect usage statistics. Usage statistics is allowed only when `UsageStatsEnabled` is true, and `UsageStatsLastUpdate` is not zero.
4. update `SetUsageStatsEnabled` in `Repository`, now if this writer is invoked, the `UsageStatsLastUpdate` will be updated as well.
5. add unit tests

resolve #206