### PR TITLE
Allow testhelpers/terminal.FakeIU to color output

### DIFF
--- a/testhelpers/terminal/test_ui.go
+++ b/testhelpers/terminal/test_ui.go
@@ -46,7 +46,7 @@ func (ui *FakeUI) Ok() {
 
 func (ui *FakeUI) Failed(template string, args ...interface{}) {
 	message := fmt.Sprintf(template, args...)
-	ui.Say(term.CrashedColor("FAILED"))
+	ui.Say(term.FailureColor("FAILED"))
 	ui.Say(message)
 }
 

--- a/testhelpers/terminal/test_ui.go
+++ b/testhelpers/terminal/test_ui.go
@@ -76,7 +76,7 @@ func (ui *FakeUI) Info(template string, args ...interface{}) {
 func (ui *FakeUI) Failed(template string, args ...interface{}) {
 	message := fmt.Sprintf(template, args...)
 	ui.Info(term.FailureColor("FAILED"))
-	ui.errror(message)
+	ui.error(message)
 	ui.Info("")
 }
 

--- a/testhelpers/terminal/test_ui.go
+++ b/testhelpers/terminal/test_ui.go
@@ -41,12 +41,12 @@ func (ui *FakeUI) Say(template string, args ...interface{}) {
 }
 
 func (ui *FakeUI) Ok() {
-	ui.Say("OK")
+	ui.Say(term.SuccessColor("OK"))
 }
 
 func (ui *FakeUI) Failed(template string, args ...interface{}) {
 	message := fmt.Sprintf(template, args...)
-	ui.Say("FAILED")
+	ui.Say(term.CrashedColor("FAILED"))
 	ui.Say(message)
 }
 

--- a/testhelpers/terminal/test_ui.go
+++ b/testhelpers/terminal/test_ui.go
@@ -60,7 +60,7 @@ func (ui *FakeUI) error(template string, args ...interface{}) {
 }
 
 func (ui *FakeUI) Ok() {
-  if ui.quiet {
+	if ui.quiet {
 		return
 	}
 	ui.Say(term.SuccessColor("OK"))


### PR DESCRIPTION
Only "OK" and "Failed" are output by this testhelper, but they should be colored if ther terminal type is fit for colorization or if color package has been forced to colorize by the unit test.

Fixes #214 