### PR TITLE
feat(cf): support load cf config v4 or later

### DIFF
--- a/bluemix/configuration/core_config/cf_config.go
+++ b/bluemix/configuration/core_config/cf_config.go
@@ -50,7 +50,7 @@ func NewCFConfigData() *CFConfigData {
 }
 
 func (data *CFConfigData) Marshal() ([]byte, error) {
-	if data.ConfigVersion == 0 {
+	if data.ConfigVersion != 3 {
 		data.ConfigVersion = 4
 	}
 	return json.MarshalIndent(data, "", "  ")

--- a/bluemix/configuration/core_config/cf_config.go
+++ b/bluemix/configuration/core_config/cf_config.go
@@ -62,6 +62,12 @@ func (data *CFConfigData) Unmarshal(bytes []byte) error {
 		return err
 	}
 
+	// clear out config if version is not 3 or 4
+	if data.ConfigVersion < 3 || data.ConfigVersion > 4 {
+		*data = CFConfigData{raw: make(map[string]interface{})}
+		return nil
+	}
+
 	var raw raw
 	err = json.Unmarshal(bytes, &raw)
 	if err != nil {

--- a/bluemix/configuration/core_config/cf_config.go
+++ b/bluemix/configuration/core_config/cf_config.go
@@ -11,30 +11,31 @@ import (
 )
 
 type CFConfigData struct {
-	ConfigVersion            int
-	Target                   string
-	APIVersion               string
-	AuthorizationEndpoint    string
-	LoggregatorEndpoint      string
-	DopplerEndpoint          string
-	UaaEndpoint              string
-	RoutingAPIEndpoint       string
-	LoginAt                  time.Time
 	AccessToken              string
-	RefreshToken             string
-	UAAOAuthClient           string
-	UAAOAuthClientSecret     string
-	SSHOAuthClient           string
-	OrganizationFields       models.OrganizationFields
-	SpaceFields              models.SpaceFields
-	SSLDisabled              bool
+	APIVersion               string
 	AsyncTimeout             uint
-	Trace                    string
+	AuthorizationEndpoint    string
 	ColorEnabled             string
+	ConfigVersion            int
+	DopplerEndpoint          string
 	Locale                   string
-	PluginRepos              []models.PluginRepo
+	LogCacheEndPoint         string
 	MinCLIVersion            string
 	MinRecommendedCLIVersion string
+	OrganizationFields       models.OrganizationFields
+	PluginRepos              []models.PluginRepo
+	RefreshToken             string
+	RoutingAPIEndpoint       string
+	SpaceFields              models.SpaceFields
+	SSHOAuthClient           string
+	SSLDisabled              bool
+	Target                   string
+	Trace                    string
+	UaaEndpoint              string
+	LoginAt                  time.Time
+	UAAGrantType             string
+	UAAOAuthClient           string
+	UAAOAuthClientSecret     string
 	raw                      raw
 }
 
@@ -49,7 +50,9 @@ func NewCFConfigData() *CFConfigData {
 }
 
 func (data *CFConfigData) Marshal() ([]byte, error) {
-	data.ConfigVersion = 3
+	if data.ConfigVersion == 0 {
+		data.ConfigVersion = 4
+	}
 	return json.MarshalIndent(data, "", "  ")
 }
 
@@ -57,11 +60,6 @@ func (data *CFConfigData) Unmarshal(bytes []byte) error {
 	err := json.Unmarshal(bytes, data)
 	if err != nil {
 		return err
-	}
-
-	if data.ConfigVersion != 3 {
-		*data = CFConfigData{raw: make(map[string]interface{})}
-		return nil
 	}
 
 	var raw raw
@@ -180,13 +178,6 @@ func (c *cfConfig) AuthenticationEndpoint() (endpoint string) {
 func (c *cfConfig) DopplerEndpoint() (endpoint string) {
 	c.read(func() {
 		endpoint = c.data.DopplerEndpoint
-	})
-	return
-}
-
-func (c *cfConfig) LoggregatorEndpoint() (endpoint string) {
-	c.read(func() {
-		endpoint = c.data.LoggregatorEndpoint
 	})
 	return
 }
@@ -356,12 +347,6 @@ func (c *cfConfig) SetAuthenticationEndpoint(endpoint string) {
 	})
 }
 
-func (c *cfConfig) SetLoggregatorEndpoint(endpoint string) {
-	c.write(func() {
-		c.data.LoggregatorEndpoint = endpoint
-	})
-}
-
 func (c *cfConfig) SetDopplerEndpoint(endpoint string) {
 	c.write(func() {
 		c.data.DopplerEndpoint = endpoint
@@ -455,7 +440,6 @@ func (c *cfConfig) UnsetAPI() {
 		c.data.AuthorizationEndpoint = ""
 		c.data.UaaEndpoint = ""
 		c.data.RoutingAPIEndpoint = ""
-		c.data.LoggregatorEndpoint = ""
 		c.data.DopplerEndpoint = ""
 	})
 }

--- a/bluemix/configuration/core_config/cf_config_test.go
+++ b/bluemix/configuration/core_config/cf_config_test.go
@@ -70,7 +70,7 @@ func TestMarshal(t *testing.T) {
 	assert.Equal(t, string(bytes), v4JSON)
 }
 
-func TestUnmarshalV3(t *testing.T) {
+func TestUnmarshalV4(t *testing.T) {
 	c := core_config.NewCFConfigData()
 	assert.NoError(t, c.Unmarshal([]byte(v4JSON)))
 
@@ -80,7 +80,7 @@ func TestUnmarshalV3(t *testing.T) {
 	assert.Equal(t, "iam.test.cloud.ibm.com", c.AuthorizationEndpoint)
 }
 
-func TestUnmarshalV4(t *testing.T) {
+func TestUnmarshalV3(t *testing.T) {
 	var v3JSON = `{
   "AccessToken": "bar",
   "APIVersion": "4",
@@ -132,6 +132,36 @@ func TestUnmarshalV4(t *testing.T) {
 	assert.Equal(t, "4", c.APIVersion)
 	assert.Equal(t, "bar", c.AccessToken)
 	assert.Equal(t, "iam.test.cloud.ibm.com", c.AuthorizationEndpoint)
+}
+
+func TestUnmarshalV2(t *testing.T) {
+	var v2JSON = `{
+  "AccessToken": "bar",
+  "APIVersion": "4",
+  "AsyncTimeout": 0,
+  "AuthorizationEndpoint": "iam.test.cloud.ibm.com",
+  "ColorEnabled": "",
+  "ConfigVersion": 2
+}`
+	c := core_config.NewCFConfigData()
+	assert.NoError(t, c.Unmarshal([]byte(v2JSON)))
+
+	assert.Empty(t, 0, c)
+}
+
+func TestUnmarshalV5(t *testing.T) {
+	var v2JSON = `{
+  "AccessToken": "bar",
+  "APIVersion": "4",
+  "AsyncTimeout": 0,
+  "AuthorizationEndpoint": "iam.test.cloud.ibm.com",
+  "ColorEnabled": "",
+  "ConfigVersion": 5
+}`
+	c := core_config.NewCFConfigData()
+	assert.NoError(t, c.Unmarshal([]byte(v2JSON)))
+
+	assert.Empty(t, 0, c)
 }
 
 func TestUnmarshalError(t *testing.T) {

--- a/bluemix/configuration/core_config/cf_config_test.go
+++ b/bluemix/configuration/core_config/cf_config_test.go
@@ -1,0 +1,140 @@
+package core_config_test
+
+import (
+	"testing"
+
+	"github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/configuration/core_config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewConfig(t *testing.T) {
+	c := core_config.NewCFConfigData()
+
+	assert.Equal(t, "cf", c.UAAOAuthClient)
+	assert.Equal(t, "", c.UAAOAuthClientSecret)
+
+}
+
+var v4JSON = `{
+  "AccessToken": "foo",
+  "APIVersion": "5",
+  "AsyncTimeout": 0,
+  "AuthorizationEndpoint": "iam.test.cloud.ibm.com",
+  "ColorEnabled": "",
+  "ConfigVersion": 4,
+  "DopplerEndpoint": "",
+  "Locale": "",
+  "LogCacheEndPoint": "",
+  "MinCLIVersion": "",
+  "MinRecommendedCLIVersion": "",
+  "OrganizationFields": {
+    "GUID": "",
+    "Name": "",
+    "QuotaDefinition": {
+      "name": "",
+      "memory_limit": 0,
+      "instance_memory_limit": 0,
+      "total_routes": 0,
+      "total_services": 0,
+      "non_basic_services_allowed": false,
+      "app_instance_limit": 0
+    }
+  },
+  "PluginRepos": null,
+  "RefreshToken": "",
+  "RoutingAPIEndpoint": "",
+  "SpaceFields": {
+    "GUID": "",
+    "Name": "",
+    "AllowSSH": false
+  },
+  "SSHOAuthClient": "",
+  "SSLDisabled": false,
+  "Target": "",
+  "Trace": "",
+  "UaaEndpoint": "",
+  "LoginAt": "0001-01-01T00:00:00Z",
+  "UAAGrantType": "",
+  "UAAOAuthClient": "cf",
+  "UAAOAuthClientSecret": ""
+}`
+
+func TestMarshal(t *testing.T) {
+	c := core_config.NewCFConfigData()
+	c.APIVersion = "5"
+	c.AccessToken = "foo"
+	c.AuthorizationEndpoint = "iam.test.cloud.ibm.com"
+
+	bytes, err := c.Marshal()
+	assert.NoError(t, err)
+	assert.Equal(t, string(bytes), v4JSON)
+}
+
+func TestUnmarshalV3(t *testing.T) {
+	c := core_config.NewCFConfigData()
+	assert.NoError(t, c.Unmarshal([]byte(v4JSON)))
+
+	assert.Equal(t, 4, c.ConfigVersion)
+	assert.Equal(t, "5", c.APIVersion)
+	assert.Equal(t, "foo", c.AccessToken)
+	assert.Equal(t, "iam.test.cloud.ibm.com", c.AuthorizationEndpoint)
+}
+
+func TestUnmarshalV4(t *testing.T) {
+	var v3JSON = `{
+  "AccessToken": "bar",
+  "APIVersion": "4",
+  "AsyncTimeout": 0,
+  "AuthorizationEndpoint": "iam.test.cloud.ibm.com",
+  "ColorEnabled": "",
+  "ConfigVersion": 3,
+  "DopplerEndpoint": "",
+  "Locale": "",
+  "LogCacheEndPoint": "",
+  "MinCLIVersion": "",
+  "MinRecommendedCLIVersion": "",
+  "OrganizationFields": {
+    "GUID": "",
+    "Name": "",
+    "QuotaDefinition": {
+      "name": "",
+      "memory_limit": 0,
+      "instance_memory_limit": 0,
+      "total_routes": 0,
+      "total_services": 0,
+      "non_basic_services_allowed": false,
+      "app_instance_limit": 0
+    }
+  },
+  "PluginRepos": null,
+  "RefreshToken": "",
+  "RoutingAPIEndpoint": "",
+  "SpaceFields": {
+    "GUID": "",
+    "Name": "",
+    "AllowSSH": false
+  },
+  "SSHOAuthClient": "",
+  "SSLDisabled": false,
+  "Target": "",
+  "Trace": "",
+  "UaaEndpoint": "",
+  "LoginAt": "0001-01-01T00:00:00Z",
+  "UAAGrantType": "",
+  "UAAOAuthClient": "cf",
+  "UAAOAuthClientSecret": ""
+}`
+
+	c := core_config.NewCFConfigData()
+	assert.NoError(t, c.Unmarshal([]byte(v3JSON)))
+
+	assert.Equal(t, 3, c.ConfigVersion)
+	assert.Equal(t, "4", c.APIVersion)
+	assert.Equal(t, "bar", c.AccessToken)
+	assert.Equal(t, "iam.test.cloud.ibm.com", c.AuthorizationEndpoint)
+}
+
+func TestUnmarshalError(t *testing.T) {
+	c := core_config.NewCFConfigData()
+	assert.Error(t, c.Unmarshal([]byte(`{"db":cf}`)))
+}

--- a/bluemix/configuration/core_config/repository.go
+++ b/bluemix/configuration/core_config/repository.go
@@ -106,7 +106,6 @@ type CFConfig interface {
 	HasAPIEndpoint() bool
 	AuthenticationEndpoint() string
 	UAAEndpoint() string
-	LoggregatorEndpoint() string
 	DopplerEndpoint() string
 	RoutingAPIEndpoint() string
 	SSHOAuthClient() string
@@ -129,7 +128,6 @@ type CFConfig interface {
 	SetAPIVersion(string)
 	SetAPIEndpoint(string)
 	SetAuthenticationEndpoint(string)
-	SetLoggregatorEndpoint(string)
 	SetDopplerEndpoint(string)
 	SetUAAEndpoint(string)
 	SetRoutingAPIEndpoint(string)


### PR DESCRIPTION
* sync latest config data from upstream cf cli project
  * remove `LoggregatorEndpoint` property and corresponding codes
  * add `UAAGrantType` property, but not setter/getter
* remove compatibility check and purge logic, we should delegate it
  to CF CLI
* set default config version to `4` if not set
* add unit test

resolve #218