### PR TITLE
feat(cf): add readers of cf config properties

### DIFF
--- a/bluemix/configuration/core_config/cf_config.go
+++ b/bluemix/configuration/core_config/cf_config.go
@@ -167,6 +167,13 @@ func (c *cfConfig) APIEndpoint() (endpoint string) {
 	return
 }
 
+func (c *cfConfig) AsyncTimeout() (timeout uint) {
+	c.read(func() {
+		timeout = c.data.AsyncTimeout
+	})
+	return
+}
+
 func (c *cfConfig) HasAPIEndpoint() (hasEndpoint bool) {
 	c.read(func() {
 		hasEndpoint = c.data.APIVersion != "" && c.data.Target != ""

--- a/bluemix/configuration/core_config/repository.go
+++ b/bluemix/configuration/core_config/repository.go
@@ -103,6 +103,8 @@ type ReadWriter interface {
 type CFConfig interface {
 	APIVersion() string
 	APIEndpoint() string
+	AsyncTimeout() uint
+	ColorEnabled() string
 	HasAPIEndpoint() bool
 	AuthenticationEndpoint() string
 	UAAEndpoint() string
@@ -114,9 +116,11 @@ type CFConfig interface {
 	Username() string
 	UserGUID() string
 	UserEmail() string
+	Locale() string
 	LoginAt() time.Time
 	IsLoggedIn() bool
 	SetLoginAt(loginAt time.Time)
+	Trace() string
 	UAAToken() string
 	UAARefreshToken() string
 	CurrentOrganization() models.OrganizationFields


### PR DESCRIPTION
1. add readers in `CFConfig` interface for properties returned in `cf
   config` command
  1.1 AsyncTimeout
  1.2 ColorEnabled
  1.3 Locale
  1.4 Trace
2. implement reader of `AsyncTimeout` in CFConfigData