### PR TITLE
fix: low asoc findings

### DIFF
--- a/bluemix/terminal/prompt.go
+++ b/bluemix/terminal/prompt.go
@@ -330,7 +330,10 @@ func readPassword(fd int) (string, error) {
 
 	go func() {
 		<-c
-		terminal.Restore(fd, oldState)
+		err := terminal.Restore(fd, oldState)
+		if err != nil {
+			fmt.Println(err.Error())
+		}
 		os.Exit(2)
 	}()
 

--- a/common/file_helpers/file.go
+++ b/common/file_helpers/file.go
@@ -53,7 +53,10 @@ func CopyFile(src string, dest string) (err error) {
 	}
 	defer destFile.Close()
 
-	destFile.Chmod(srcStat.Mode())
+	err = destFile.Chmod(srcStat.Mode())
+	if err != nil {
+		return
+	}
 
 	_, err = io.Copy(destFile, srcFile)
 	return

--- a/common/rest/request.go
+++ b/common/rest/request.go
@@ -245,7 +245,10 @@ func (r *Request) buildFormMultipart() (io.Reader, error) {
 		for _, f := range files {
 			defer func() {
 				if f, ok := f.Content.(io.ReadCloser); ok {
-					f.Close()
+					err := f.Close()
+					if err != nil {
+						fmt.Println(err.Error())
+					}
 				}
 			}()
 

--- a/plugin/plugin_shim.go
+++ b/plugin/plugin_shim.go
@@ -23,7 +23,10 @@ func StartWithArgs(plugin Plugin, args []string) {
 		if err != nil {
 			panic(err)
 		}
-		os.Stdout.Write(json)
+		_, err = os.Stdout.Write(json)
+		if err != nil {
+			panic(err)
+		}
 		return
 	}
 

--- a/plugin_examples/list_plugin/plugin.go
+++ b/plugin_examples/list_plugin/plugin.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"time"
+	"fmt"
 
 	bhttp "github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/http"
 	"github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/terminal"
@@ -92,7 +93,10 @@ func NewHTTPClient(context plugin.PluginContext) *http.Client {
 }
 
 func DefaultHeader(cf plugin.CFContext) http.Header {
-	cf.RefreshUAAToken()
+	_, err := cf.RefreshUAAToken()
+	if err != nil {
+		fmt.Println(err.Error())
+	}
 
 	h := http.Header{}
 	h.Add("Authorization", cf.UAAToken())


### PR DESCRIPTION
```
go test ./...
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix  (cached)
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/authentication   [no test files]
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/authentication/iam       [no test files]
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/authentication/uaa       [no test files]
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/configuration    [no test files]
# github.com/IBM-Cloud/ibm-cloud-cli-sdk/plugin_examples
plugin_examples/context.go:14:6: main redeclared in this block
        previous declaration at plugin_examples/auto_complete_delegation.go:12:6
plugin_examples/hello.go:11:6: main redeclared in this block
        previous declaration at plugin_examples/context.go:14:6
plugin_examples/namespace.go:11:6: main redeclared in this block
        previous declaration at plugin_examples/hello.go:11:6
plugin_examples/stage.go:11:6: main redeclared in this block
        previous declaration at plugin_examples/namespace.go:11:6
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/configuration/config_helpers     (cached)
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/configuration/core_config        0.904s
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/crn      (cached)
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/endpoints        (cached)
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/http     (cached)
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/models   [no test files]
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/terminal (cached)
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/trace    (cached)
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/common/downloader        (cached)
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/common/file_helpers      [no test files]
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/common/rest      (cached)
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/common/types     [no test files]
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/i18n     [no test files]
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/plugin   (cached)
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/plugin/pluginfakes       [no test files]
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/plugin_examples/list_plugin/api  (cached)
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/plugin_examples/list_plugin/commands     (cached)
```

ref: https://github.ibm.com/Bluemix/bluemix-cli/issues/3567