### PR TITLE
provide a field that indicates if a value is given for a prompt

### DIFF
--- a/bluemix/terminal/prompt.go
+++ b/bluemix/terminal/prompt.go
@@ -43,6 +43,8 @@ type Prompt struct {
 
 	Reader io.Reader
 	Writer io.Writer
+
+	ValueProvided bool
 }
 
 // NewPrompt returns a single prompt
@@ -67,6 +69,8 @@ func NewChoicesPrompt(message string, choices []string, options *PromptOptions) 
 
 // Resolve reads user input and resolves it to the destination value
 func (p *Prompt) Resolve(dest interface{}) error {
+	p.ValueProvided = false
+
 	if len(p.choices) > 0 {
 		return p.resolveChoices(dest)
 	}
@@ -92,6 +96,8 @@ func (p *Prompt) resolveSingle(dest interface{}) error {
 				err = ErrInputEmpty
 			}
 		} else {
+			p.ValueProvided = true
+
 			if p.options.ValidateFunc != nil {
 				err = p.options.ValidateFunc(input)
 			}
@@ -235,6 +241,8 @@ func (p *Prompt) resolveChoices(dest interface{}) error {
 				err = ErrInputEmpty
 			}
 		} else {
+			p.ValueProvided = true
+
 			selectedNum, err = strconv.Atoi(input)
 			if err != nil {
 				err = ErrInputNotNumber


### PR DESCRIPTION
I have a use case in writing CLI plugins that is not currently supported by the SDK. When accepting input interactively, using the `Prompt` function, I would like a way to be able to determine if the user provided a value or not.

For example - say I prompt for an optional, boolean value. If the user skips the prompt, i.e. they just press "Enter", I would like to take one path and if the user enters "n", I would like to take another path. Currently, it is impossible to distinguish between the two.

This PR adds a single field to the `Prompt` type, `ValueProvided`, that will be set to true if the user provides any input and will remain false if the input is empty. The type is public so that it can be accessed by the developer using the SDK.

I am planning to write tests/documentation for this change but first, I want to see what your thoughts on this change are. Is this something you would be willing to add to the package?