### PR TITLE
feat: add support for parsing yaml response bodies **DO NOT MERGE**

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/*
+!vendor/vendor.json

--- a/common/rest/client_test.go
+++ b/common/rest/client_test.go
@@ -35,10 +35,65 @@ func TestDoWithContext_WithSuccessV(t *testing.T) {
 	assert.Equal("bar", res["foo"])
 }
 
+func TestDoWithContext_WithSuccessYAML(t *testing.T) {
+	assert := assert.New(t)
+
+	ts := httptest.NewServer(serveHandler(200, "\"foo\": \"bar\""))
+	defer ts.Close()
+
+	var res map[string]string
+	resp, err := NewClient().DoWithContext(context.TODO(), GetRequest(ts.URL), &res, nil)
+	assert.NoError(err)
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	assert.Equal("bar", res["foo"])
+}
+
+func TestDoWithContext_WithSuccessComplexYAML(t *testing.T) {
+	assert := assert.New(t)
+
+	ts := httptest.NewServer(serveHandler(200, `
+---
+doe: "a deer, a female deer"
+ray: "a drop of golden sun"
+pi: 3.14159
+xmas: true
+french-hens: 3
+calling-birds:
+  - huey
+  - dewey
+  - louie
+  - fred`))
+	defer ts.Close()
+
+	var res map[string]interface{}
+	resp, err := NewClient().DoWithContext(context.TODO(), GetRequest(ts.URL), &res, nil)
+	assert.NoError(err)
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	assert.Equal("a deer, a female deer", res["doe"])
+	assert.Equal("a drop of golden sun", res["ray"])
+	assert.Equal(3.14159, res["pi"])
+	assert.Equal(true, res["xmas"])
+	callingBirds := []interface{}{"huey", "dewey", "louie", "fred"}
+	assert.Equal(callingBirds, res["calling-birds"])
+}
+
 func TestDoWithContext_NilContext_WithSuccessV(t *testing.T) {
 	assert := assert.New(t)
 
 	ts := httptest.NewServer(serveHandler(200, "{\"foo\": \"bar\"}"))
+	defer ts.Close()
+
+	var res map[string]string
+	resp, err := NewClient().DoWithContext(nil, GetRequest(ts.URL), &res, nil)
+	assert.NoError(err)
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	assert.Equal("bar", res["foo"])
+}
+
+func TestDoWithContext_NilContext_WithSuccessYAML(t *testing.T) {
+	assert := assert.New(t)
+
+	ts := httptest.NewServer(serveHandler(200, "\"foo\": \"bar\""))
 	defer ts.Close()
 
 	var res map[string]string
@@ -63,6 +118,19 @@ func TestDo_WithSuccessV(t *testing.T) {
 	assert := assert.New(t)
 
 	ts := httptest.NewServer(serveHandler(200, "{\"foo\": \"bar\"}"))
+	defer ts.Close()
+
+	var res map[string]string
+	resp, err := NewClient().Do(GetRequest(ts.URL), &res, nil)
+	assert.NoError(err)
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	assert.Equal("bar", res["foo"])
+}
+
+func TestDo_WithSuccessYAML(t *testing.T) {
+	assert := assert.New(t)
+
+	ts := httptest.NewServer(serveHandler(200, "\"foo\": \"bar\""))
 	defer ts.Close()
 
 	var res map[string]string

--- a/common/rest/helpers/client_helpers.go
+++ b/common/rest/helpers/client_helpers.go
@@ -1,0 +1,36 @@
+package rest
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"unicode"
+)
+
+var jsonPrefix = []byte("{")
+var jsonArrayPrefix = []byte("[")
+
+// IsJSONStream scans the provided reader up to size, looking
+// for a json prefix indicating this is JSON. It will return the
+// bufio.Reader it creates for the consumer. The buffer size will at either be the size of 'size'
+// or the size of the Reader passed in 'r', whichever is larger.
+// Inspired from https://github.com/kubernetes/apimachinery/blob/v0.21.0/pkg/util/yaml/decoder.go
+func IsJSONStream(r io.Reader, size int) (io.Reader, bool) {
+	buffer := bufio.NewReaderSize(r, size)
+	b, _ := buffer.Peek(size)
+	return buffer, containsJSON(b)
+}
+
+// containsJSON returns true if the provided buffer appears to start with
+// a JSON open brace or JSON open bracket.
+// Inspired from https://github.com/kubernetes/apimachinery/blob/v0.21.0/pkg/util/yaml/decoder.go
+func containsJSON(buf []byte) bool {
+	return hasPrefix(buf, jsonPrefix) || hasPrefix(buf, jsonArrayPrefix)
+}
+
+// Return true if the first non-whitespace bytes in buf is
+// prefix.
+func hasPrefix(buf []byte, prefix []byte) bool {
+	trim := bytes.TrimLeftFunc(buf, unicode.IsSpace)
+	return bytes.HasPrefix(trim, prefix)
+}

--- a/common/rest/helpers/client_helpers_test.go
+++ b/common/rest/helpers/client_helpers_test.go
@@ -1,0 +1,175 @@
+package rest
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var chunkSize int
+
+func TestIsJSONStreamWithJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	chunkSize = 1024
+	jsonBytes := []byte(`{
+		"foo": {
+			"bar": 1
+			"otherStuff": 2
+		}
+	}`)
+	jsonBytesAsString := string(jsonBytes)
+
+	r, isJSON := IsJSONStream(bytes.NewReader(jsonBytes), chunkSize)
+
+	assert.NotNil(r)
+
+	raw, _ := ioutil.ReadAll(r)
+
+	assert.NotNil(raw)
+	assert.True(isJSON)
+	assert.Equal(jsonBytesAsString, string(raw))
+}
+
+func TestIsJSONStreamWithJSONArray(t *testing.T) {
+	assert := assert.New(t)
+
+	chunkSize = 1024
+	jsonBytes := []byte(`[
+		{
+			"foo": {
+				"bar": 1
+				"otherStuff": 2
+			}
+		},
+		{
+			"foo2": {
+				"bar": 1
+				"otherStuff": 2
+			}
+		}
+	]`)
+	jsonBytesAsString := string(jsonBytes)
+
+	r, isJSON := IsJSONStream(bytes.NewReader(jsonBytes), chunkSize)
+
+	assert.NotNil(r)
+
+	raw, _ := ioutil.ReadAll(r)
+
+	assert.NotNil(raw)
+	assert.True(isJSON)
+	assert.Equal(jsonBytesAsString, string(raw))
+}
+
+func TestIsJSONStreamWithInvalidJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	chunkSize = 1024
+	jsonBytes := []byte(`
+		"foo": {
+			"bar": 1
+			"otherStuff": 2
+		}
+	`)
+	jsonBytesAsString := string(jsonBytes)
+
+	r, isJSON := IsJSONStream(bytes.NewReader(jsonBytes), chunkSize)
+
+	assert.NotNil(r)
+
+	raw, _ := ioutil.ReadAll(r)
+
+	assert.NotNil(raw)
+	assert.False(isJSON)
+	assert.Equal(jsonBytesAsString, string(raw))
+}
+
+func TestIsJSONStreamWithString(t *testing.T) {
+	assert := assert.New(t)
+
+	chunkSize = 1024
+	jsonBytes := []byte("foobar")
+	jsonBytesAsString := string(jsonBytes)
+
+	r, isJSON := IsJSONStream(bytes.NewReader(jsonBytes), chunkSize)
+
+	assert.NotNil(r)
+
+	raw, _ := ioutil.ReadAll(r)
+
+	assert.NotNil(raw)
+	assert.False(isJSON)
+	assert.Equal(jsonBytesAsString, string(raw))
+}
+
+func TestIsJSONStreamWithYAML(t *testing.T) {
+	assert := assert.New(t)
+
+	chunkSize = 1024
+	jsonBytes := []byte(`---
+	foo:
+	- bar: jon_snow
+	  description: "The king of the north"
+	  created: 2016-01-14
+	  updated: 2019-08-16
+	  company: IBM
+	`)
+	jsonBytesAsString := string(jsonBytes)
+
+	r, isJSON := IsJSONStream(bytes.NewReader(jsonBytes), chunkSize)
+
+	assert.NotNil(r)
+
+	raw, _ := ioutil.ReadAll(r)
+
+	assert.NotNil(raw)
+	assert.False(isJSON)
+	assert.Equal(jsonBytesAsString, string(raw))
+}
+
+func TestIsJSONStreamWithYamlArray(t *testing.T) {
+	assert := assert.New(t)
+
+	chunkSize = 1024
+	jsonBytes := []byte(`
+	items:
+	  - things:
+		  thing1: huey
+		  things2: dewey
+		  thing3: louie
+	  - other things:
+		  key: value
+	`)
+	jsonBytesAsString := string(jsonBytes)
+
+	r, isJSON := IsJSONStream(bytes.NewReader(jsonBytes), chunkSize)
+
+	assert.NotNil(r)
+
+	raw, _ := ioutil.ReadAll(r)
+
+	assert.NotNil(raw)
+	assert.False(isJSON)
+	assert.Equal(jsonBytesAsString, string(raw))
+}
+
+func TestIsJSONStreamWithEmptyString(t *testing.T) {
+	assert := assert.New(t)
+
+	chunkSize = 1024
+	jsonBytes := []byte("")
+	jsonBytesAsString := string(jsonBytes)
+
+	r, isJSON := IsJSONStream(bytes.NewReader(jsonBytes), chunkSize)
+
+	assert.NotNil(r)
+
+	raw, _ := ioutil.ReadAll(r)
+
+	assert.NotNil(raw)
+	assert.False(isJSON)
+	assert.Equal(jsonBytesAsString, string(raw))
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -303,10 +303,10 @@
 			"revisionTime": "2017-05-08T13:24:47Z"
 		},
 		{
-			"checksumSHA1": "0KwOlQV1dNUh9X8t+5s7nX5bqfk=",
+			"checksumSHA1": "RqcbcMbbS5iVjpckNxDc30/WYSE=",
 			"path": "gopkg.in/yaml.v2",
-			"revision": "a3f3340b5840cee44f372bddb5880fcbc419b46a",
-			"revisionTime": "2017-02-08T14:18:51Z"
+			"revision": "7649d4548cb53a614db133b2a8ac1f31859dda8c",
+			"revisionTime": "2020-11-17T15:46:20Z"
 		}
 	],
 	"rootPath": "github.com/IBM-Cloud/ibm-cloud-cli-sdk"


### PR DESCRIPTION
This PR adds support for decoding yaml response bodies in the rest client. When a response body is received, now the client will attempt to identify the bytes as either a json or yaml response body. In the case of the body being in yaml format, the [go-yaml](https://github.com/go-yaml/yaml/tree/v2.4.0) decoder is used to unmarshal the response.

The go-yaml package was updated to v2.4.0

ref: https://github.ibm.com/Bluemix/bluemix-cli/issues/3481