### PR TITLE
use os.Chmod instead of file.Chmod for Windows compatibility

### DIFF
--- a/common/file_helpers/file.go
+++ b/common/file_helpers/file.go
@@ -53,7 +53,7 @@ func CopyFile(src string, dest string) (err error) {
 	}
 	defer func() { _ = destFile.Close() }()
 
-	err = destFile.Chmod(srcStat.Mode())
+	err = os.Chmod(dest, srcStat.Mode())
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This PR updates the `CopyFile` method to use Go's [Chmod](https://golang.org/pkg/os/#Chmod) ``os`` function since it's compatible across different operating systems. This bug was exposed through the addition of error handling: https://github.com/IBM-Cloud/ibm-cloud-cli-sdk/commit/f322ddbdca7b23ff9bb13f29f4c5fd6ed009fd93#diff-ed4c5da476b144b27ead262d23553593edc97ab9030fdca07a62ec5166408447R56

Fixes 
```
Installing binary...
FAILED
Unable to copy the plug-in binary: chmod C:\Users\Administrator\.bluemix\plugins\container-registry\container-registry.exe: not supported by windows
```
on windows.