### PR TITLE
chore: ignore gosec false positive

### DIFF
--- a/bluemix/authentication/iam/iam.go
+++ b/bluemix/authentication/iam/iam.go
@@ -33,7 +33,7 @@ const (
 	GrantTypeDelegatedRefreshToken authentication.GrantType = "urn:ibm:params:oauth:grant-type:delegated-refresh-token" // #nosec G101
 	GrantTypeIdentityCookie        authentication.GrantType = "urn:ibm:params:oauth:grant-type:identity-cookie"
 	GrantTypeDerive                authentication.GrantType = "urn:ibm:params:oauth:grant-type:derive"
-	GrantTypeCRToken               authentication.GrantType = "urn:ibm:params:oauth:grant-type:cr-token"
+	GrantTypeCRToken               authentication.GrantType = "urn:ibm:params:oauth:grant-type:cr-token" // #nosec G101
 )
 
 // Response types


### PR DESCRIPTION
False positive found by `gosec` during vulnerability scan: https://github.ibm.com/arf/security-and-compliance/blob/master/asoc/reports/20210919160307/cli-squad_ibm-cloud-cli-sdk.html

The keyword "token" is causing the scan to think a sensitive value is being revealed