### PR TITLE
feat: add support for vpc authentication

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-09-16T21:05:25Z",
+  "generated_at": "2021-10-06T19:12:04Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -168,12 +168,30 @@
         "verified_result": null
       }
     ],
+    "bluemix/authentication/vpc/vpc_test.go": [
+      {
+        "hashed_secret": "baa11828b713288370b2ae5b7dd012ab8e875ca7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c8f0df25bade89c1873f5f01b85bcfb921443ac6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 20,
+        "type": "JSON Web Token",
+        "verified_result": null
+      }
+    ],
     "bluemix/configuration/core_config/bx_config_test.go": [
       {
         "hashed_secret": "9507a758af9127f99a700b500657fd558b705dc9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 274,
+        "line_number": 303,
         "type": "JSON Web Token",
         "verified_result": null
       }

--- a/bluemix/authentication/vpc/vpc.go
+++ b/bluemix/authentication/vpc/vpc.go
@@ -1,0 +1,215 @@
+package vpc
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/authentication/iam"
+	"github.com/IBM-Cloud/ibm-cloud-cli-sdk/common/rest"
+)
+
+const (
+	DefaultMetadataServiceVersion = "2021-09-30"
+	DefaultServerEndpoint         = "http://169.254.169.254"
+
+	defaultMetadataFlavor                 = "ibm"
+	defaultInstanceIdentityTokenLifetime  = 300
+	defaultOperationPathCreateAccessToken = "/instance_identity/v1/token"
+	defaultOperationPathCreateIamToken    = "/instance_identity/v1/iam_token"
+
+	// headers
+	MetadataFlavor = "Metadata-Flavor"
+
+	contentType   = "Content-Type"
+	authorization = "Authorization"
+	tokenType     = "Bearer"
+)
+
+// InstanceIdentityToken describes the response body for the 'GetInstanceIdentityToken'
+// operation.
+type InstanceIdentityToken struct {
+	// The access token
+	AccessToken string `json:"access_token"`
+	// The date and time that the access token was created
+	CreatedAt string `json:"created_at"`
+	// The date and time that the access token will expire
+	ExpiresAt string `json:"expires_at"`
+	// Time in seconds before the access token expires
+	ExpiresIn int `json:"expires_in"`
+}
+
+// getIAMAccessTokenResponse describes the response body for the 'GetIAMAccessToken'
+// operation.
+type getIAMAccessTokenResponse struct {
+	// The access token
+	AccessToken string `json:"access_token"`
+	// The date and time that the access token was created
+	CreatedAt string `json:"created_at"`
+	// The date and time that the access token will expire
+	ExpiresAt string `json:"expires_at"`
+	// Time in seconds before the access token expires
+	ExpiresIn int `json:"expires_in"`
+}
+
+type Interface interface {
+	GetInstanceIdentityToken() (*InstanceIdentityToken, error)
+	GetIAMAccessToken(req *IAMAccessTokenRequest) (*iam.Token, error)
+}
+
+type Config struct {
+	VPCAuthEndpoint              string
+	InstanceIdentiyTokenEndpoint string
+	IAMTokenEndpoint             string
+	Version                      string
+}
+
+// IAMAccessTokenRequest represents the request object for the `GetIAMAccessToken` operation.
+// AccessToken - The instance identity token
+// Body - The trusted profile ID/CRN represented as the `TrustedProfileByIdOrCRN` object
+type IAMAccessTokenRequest struct {
+	AccessToken string `json:"access_token"`
+	Body        *TrustedProfileByIdOrCRN
+}
+
+type TrustedProfileByIdOrCRN struct {
+	ID  string `json:"id"`
+	CRN string `json:"crn"`
+}
+
+// NewIAMAccessTokenRequest builds the request body for the GetIAMAccessToken
+// operation. The request body for this operation consists of either a trusted profile
+// ID or CRN. If both a trusted profile ID and a trusted profile CRN are provided, then
+// an error is returned.
+func NewIAMAccessTokenRequest(profileID string, profileCRN string, token string) (*IAMAccessTokenRequest, error) {
+	var trustedProfile TrustedProfileByIdOrCRN
+
+	if profileID != "" && profileCRN != "" {
+		return nil, fmt.Errorf("A Profile ID and Profile CRN cannot both be specified.")
+	}
+
+	if profileCRN != "" {
+		trustedProfile.CRN = profileCRN
+	}
+	if profileID != "" {
+		trustedProfile.ID = profileID
+	}
+
+	request := &IAMAccessTokenRequest{
+		Body:        &trustedProfile,
+		AccessToken: token,
+	}
+
+	return request, nil
+}
+
+func (c Config) instanceIdentityTokenEndpoint() string {
+	if c.InstanceIdentiyTokenEndpoint != "" {
+		return c.InstanceIdentiyTokenEndpoint
+	}
+	return c.VPCAuthEndpoint + defaultOperationPathCreateAccessToken
+}
+
+func (c Config) iamTokenEndpoint() string {
+	if c.IAMTokenEndpoint != "" {
+		return c.IAMTokenEndpoint
+	}
+	return c.VPCAuthEndpoint + defaultOperationPathCreateIamToken
+}
+
+func DefaultConfig(vpcAuthEndpoint string, apiVersion string) Config {
+	return Config{
+		VPCAuthEndpoint:              vpcAuthEndpoint,
+		InstanceIdentiyTokenEndpoint: vpcAuthEndpoint + defaultOperationPathCreateAccessToken,
+		IAMTokenEndpoint:             vpcAuthEndpoint + defaultOperationPathCreateIamToken,
+		Version:                      apiVersion,
+	}
+}
+
+type client struct {
+	config Config
+	client *rest.Client
+}
+
+func NewClient(config Config, restClient *rest.Client) Interface {
+	return &client{
+		config: config,
+		client: restClient,
+	}
+}
+
+// GetInstanceIdentityToken retrieves the VPC/VSI compute resource's instance identity token specified at
+// `c.config.VPCAuthEndpoint` using the "create_access_token" operation of the VPC Instance Metadata Service API.
+func (c *client) GetInstanceIdentityToken() (*InstanceIdentityToken, error) {
+	req := rest.PutRequest(c.config.instanceIdentityTokenEndpoint())
+	// set headers
+	req.Set(MetadataFlavor, defaultMetadataFlavor)
+	// set query params
+	req.Query("version", c.config.Version)
+
+	// create body
+	body := fmt.Sprintf("{\"expires_in\": \"%d\"}", defaultInstanceIdentityTokenLifetime)
+	req.Body(body)
+
+	var tokenResponse struct {
+		InstanceIdentityToken
+	}
+
+	_, err := c.client.Do(req, &tokenResponse, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := tokenResponse.InstanceIdentityToken
+
+	return &ret, nil
+}
+
+// GetIAMAccessToken exchanges the VPC/VSI compute resource's instance identity token for an IAM access token at
+// `c.config.VPCAuthEndpoint` using the "create_iam_token" operation of the VPC Instance Metadata Service API.
+// The request body can consist of a profile CRN or ID, but not both.
+func (c *client) GetIAMAccessToken(tokenReq *IAMAccessTokenRequest) (*iam.Token, error) {
+	req := rest.PostRequest(c.config.iamTokenEndpoint())
+	// set instance identity token
+	req.Set(authorization, "Bearer "+tokenReq.AccessToken)
+	req.Query("version", c.config.Version)
+
+	if tokenReq.Body != nil {
+		var body string
+		profileID := tokenReq.Body.ID
+		profileCRN := tokenReq.Body.CRN
+
+		if profileID != "" {
+			body = fmt.Sprintf(`{"trusted_profile": {"id": "%s"}}`, profileID)
+		} else if profileCRN != "" {
+			body = fmt.Sprintf(`{"trusted_profile": {"crn": "%s"}}`, profileCRN)
+		}
+
+		if body != "" {
+			req.Body(body)
+		}
+
+	}
+
+	var tokenResponse struct {
+		getIAMAccessTokenResponse
+	}
+
+	// error codes have not been defined, so return raw error from server
+	_, err := c.client.Do(req, &tokenResponse, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// convert tokenResponse to an IAM token to maintain compatibility
+	expiry, err := time.Parse(time.RFC3339, tokenResponse.ExpiresAt)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing access token expiration %s", err)
+	}
+	iamToken := &iam.Token{
+		AccessToken: tokenResponse.AccessToken,
+		Expiry:      expiry,
+		TokenType:   tokenType,
+	}
+
+	return iamToken, nil
+}

--- a/bluemix/authentication/vpc/vpc_test.go
+++ b/bluemix/authentication/vpc/vpc_test.go
@@ -1,0 +1,397 @@
+package vpc_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/assert"
+
+	"github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/authentication/vpc"
+	"github.com/IBM-Cloud/ibm-cloud-cli-sdk/common/rest"
+)
+
+const (
+	instanceIdentityToken string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0aGVfYmVzdCI6IkVyaWNhIn0.c4C_BKtyZ4g78TB6wjdsX_MNx4KPoYj8YiikB1jO4o8"
+	iamAccessToken        string = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI"
+
+	applicationJson = "application/json"
+	authorization   = "Authorization"
+	contentType     = "Content-Type"
+
+	mockProfileID  = "Profile-123"
+	mockProfileCRN = "crn:iam-profile:12345"
+)
+
+var currentTime time.Time = time.Now()
+
+func TestDefaultConfig(t *testing.T) {
+	config := vpc.DefaultConfig("http://mockUrl", vpc.DefaultMetadataServiceVersion)
+	assert.Equal(t, "http://mockUrl", config.VPCAuthEndpoint)
+	assert.Equal(t, "http://mockUrl/instance_identity/v1/token", config.InstanceIdentiyTokenEndpoint)
+	assert.Equal(t, "http://mockUrl/instance_identity/v1/iam_token", config.IAMTokenEndpoint)
+	assert.Equal(t, vpc.DefaultMetadataServiceVersion, config.Version)
+
+}
+func TestIAMAccessTokenRequestWithProfileID(t *testing.T) {
+	// build a mock token request with ProfileID
+	req, err := vpc.NewIAMAccessTokenRequest(mockProfileID, "", instanceIdentityToken)
+	assert.Nil(t, err)
+	assert.NotNil(t, req)
+
+	// validate the request
+	assert.Equal(t, instanceIdentityToken, req.AccessToken)
+	assert.NotNil(t, req.Body)
+	assert.Empty(t, req.Body.CRN)
+	assert.Equal(t, mockProfileID, req.Body.ID)
+}
+
+func TestIAMAccessTokenRequestWithProfileCRN(t *testing.T) {
+	// build a mock token request with ProfileCRN
+	req, err := vpc.NewIAMAccessTokenRequest("", mockProfileCRN, instanceIdentityToken)
+	assert.Nil(t, err)
+	assert.NotNil(t, req)
+
+	// validate the request
+	assert.Equal(t, instanceIdentityToken, req.AccessToken)
+	assert.NotNil(t, req.Body)
+	assert.Empty(t, req.Body.ID)
+	assert.Equal(t, mockProfileCRN, req.Body.CRN)
+}
+
+func TestIAMAccessTokenRequestWithoutToken(t *testing.T) {
+	// build a mock token request with ProfileCRN
+	req, err := vpc.NewIAMAccessTokenRequest("", mockProfileCRN, "")
+	assert.Nil(t, err)
+	assert.NotNil(t, req)
+
+	// validate the request
+	assert.Empty(t, req.AccessToken)
+	assert.NotNil(t, req.Body)
+	assert.Empty(t, req.Body.ID)
+	assert.Equal(t, mockProfileCRN, req.Body.CRN)
+}
+
+func TestIAMAccessTokenRequestFailure(t *testing.T) {
+	req, err := vpc.NewIAMAccessTokenRequest(mockProfileID, mockProfileCRN, instanceIdentityToken)
+	assert.NotNil(t, err)
+	assert.Equal(t, "A Profile ID and Profile CRN cannot both be specified.", err.Error())
+	assert.Nil(t, req)
+}
+
+func TestGetInstanceIdentiyTokenSuccess(t *testing.T) {
+	server := startMockVPCServerForTokenExchange(t, http.StatusOK, false, false, true)
+	defer server.Close()
+
+	mockServerEndpoint := server.URL
+	mockConfig := vpc.DefaultConfig(mockServerEndpoint, vpc.DefaultMetadataServiceVersion)
+	mockClient := vpc.NewClient(mockConfig, rest.NewClient())
+
+	// attempt to fetch the token
+	identityToken, err := mockClient.GetInstanceIdentityToken()
+
+	assert.Nil(t, err)
+	assert.Equal(t, instanceIdentityToken, identityToken.AccessToken)
+	assert.Equal(t, 300, identityToken.ExpiresIn)
+	assert.NotEmpty(t, identityToken.ExpiresAt)
+
+	// expiry should be 5 minutes in the future
+	expectedExpiry := currentTime.Add(time.Second * 300).UTC().Format(time.RFC3339)
+	assert.Equal(t, expectedExpiry, identityToken.ExpiresAt)
+
+}
+
+func TestGetInstanceIdentiyTokenFailure(t *testing.T) {
+	server := startMockVPCServerForTokenExchange(t, http.StatusUnauthorized, false, false, true)
+	defer server.Close()
+
+	mockServerEndpoint := server.URL
+	mockConfig := vpc.DefaultConfig(mockServerEndpoint, vpc.DefaultMetadataServiceVersion)
+	mockClient := vpc.NewClient(mockConfig, rest.NewClient())
+
+	// attempt to fetch the token
+	identityToken, err := mockClient.GetInstanceIdentityToken()
+
+	assert.NotNil(t, err)
+	assert.Nil(t, identityToken)
+}
+
+func TestGetIAMAccessTokenSuccessWProfileID(t *testing.T) {
+	server := startMockVPCServerForTokenExchange(t, http.StatusOK, false, true, true)
+	defer server.Close()
+
+	mockServerEndpoint := server.URL
+	mockConfig := vpc.DefaultConfig(mockServerEndpoint, vpc.DefaultMetadataServiceVersion)
+	mockClient := vpc.NewClient(mockConfig, rest.NewClient())
+
+	// build the request using a mock profile ID
+	req, err := vpc.NewIAMAccessTokenRequest(mockProfileID, "", instanceIdentityToken)
+	assert.Nil(t, err)
+	assert.NotNil(t, req)
+	// validate token
+	assert.Equal(t, instanceIdentityToken, req.AccessToken)
+	// validate the request body
+	trustedProfile := req.Body
+	assert.NotNil(t, trustedProfile)
+	assert.NotNil(t, trustedProfile.ID)
+	assert.Empty(t, trustedProfile.CRN)
+	assert.Equal(t, mockProfileID, trustedProfile.ID)
+	// attempt to fetch the token
+	iamToken, err := mockClient.GetIAMAccessToken(req)
+
+	assert.Nil(t, err)
+	assert.Equal(t, iamAccessToken, iamToken.AccessToken)
+	// expiry should be 1 hour in the future
+	expectedExpiry := currentTime.Unix() + 3600
+	assert.Equal(t, expectedExpiry, iamToken.Expiry.Unix())
+
+}
+
+func TestGetIAMAccessTokenSuccessWithoutBody1(t *testing.T) {
+	server := startMockVPCServerForTokenExchange(t, http.StatusOK, false, false, false)
+	defer server.Close()
+
+	mockServerEndpoint := server.URL
+	mockConfig := vpc.DefaultConfig(mockServerEndpoint, vpc.DefaultMetadataServiceVersion)
+	mockClient := vpc.NewClient(mockConfig, rest.NewClient())
+
+	// build the request manually without a body
+	trustedProfile := vpc.TrustedProfileByIdOrCRN{}
+	req := vpc.IAMAccessTokenRequest{
+		AccessToken: instanceIdentityToken,
+		Body:        &trustedProfile,
+	}
+	// attempt to fetch the token
+	iamToken, err := mockClient.GetIAMAccessToken(&req)
+	assert.Nil(t, err)
+	assert.Equal(t, iamAccessToken, iamToken.AccessToken)
+	// expiry should be 1 hour in the future
+	expectedExpiry := currentTime.Unix() + 3600
+	assert.Equal(t, expectedExpiry, iamToken.Expiry.Unix())
+
+	// build the same request but using the `NewIAMAccessTokenRequest` method
+	newReq, err := vpc.NewIAMAccessTokenRequest("", "", instanceIdentityToken)
+	assert.Nil(t, err)
+	assert.NotNil(t, newReq.Body)
+	// attempt to fetch another token
+	iamToken, err = mockClient.GetIAMAccessToken(newReq)
+	assert.Nil(t, err)
+	assert.Equal(t, iamAccessToken, iamToken.AccessToken)
+}
+
+func TestGetIAMAccessTokenSuccessWithoutBody2(t *testing.T) {
+	server := startMockVPCServerForTokenExchange(t, http.StatusOK, false, false, false)
+	defer server.Close()
+
+	mockServerEndpoint := server.URL
+	mockConfig := vpc.DefaultConfig(mockServerEndpoint, vpc.DefaultMetadataServiceVersion)
+	mockClient := vpc.NewClient(mockConfig, rest.NewClient())
+
+	// build the request manually without a body
+	req := vpc.IAMAccessTokenRequest{
+		AccessToken: instanceIdentityToken,
+	}
+	assert.Nil(t, req.Body)
+	// attempt to fetch the token
+	iamToken, err := mockClient.GetIAMAccessToken(&req)
+	assert.Nil(t, err)
+	assert.Equal(t, iamAccessToken, iamToken.AccessToken)
+	// expiry should be 1 hour in the future
+	expectedExpiry := currentTime.Unix() + 3600
+	assert.Equal(t, expectedExpiry, iamToken.Expiry.Unix())
+
+	// build the same request but using the `NewIAMAccessTokenRequest` method
+	newReq, err := vpc.NewIAMAccessTokenRequest("", "", instanceIdentityToken)
+	assert.Nil(t, err)
+	assert.NotNil(t, newReq.Body)
+	// attempt to fetch another token
+	iamToken, err = mockClient.GetIAMAccessToken(newReq)
+	assert.Nil(t, err)
+	assert.Equal(t, iamAccessToken, iamToken.AccessToken)
+}
+
+func TestGetIAMAccessTokenFailureWProfileID(t *testing.T) {
+	server := startMockVPCServerForTokenExchange(t, http.StatusBadRequest, false, true, true)
+	defer server.Close()
+
+	mockServerEndpoint := server.URL
+	mockConfig := vpc.DefaultConfig(mockServerEndpoint, vpc.DefaultMetadataServiceVersion)
+	mockClient := vpc.NewClient(mockConfig, rest.NewClient())
+
+	// build the request using a mock profile ID
+	req, err := vpc.NewIAMAccessTokenRequest(mockProfileID, "", "")
+	assert.Nil(t, err)
+	assert.NotNil(t, req)
+	// validate token
+	assert.Empty(t, req.AccessToken)
+	// validate the request body
+	trustedProfile := req.Body
+	assert.NotNil(t, trustedProfile)
+	assert.NotNil(t, trustedProfile.ID)
+	assert.Empty(t, trustedProfile.CRN)
+	assert.Equal(t, mockProfileID, trustedProfile.ID)
+	// attempt to fetch the token
+	iamToken, err := mockClient.GetIAMAccessToken(req)
+
+	assert.NotNil(t, err)
+	assert.Nil(t, iamToken)
+}
+
+func TestGetIAMAccessTokenSuccessWProfileCRN(t *testing.T) {
+	server := startMockVPCServerForTokenExchange(t, http.StatusOK, true, false, true)
+	defer server.Close()
+
+	mockServerEndpoint := server.URL
+	mockConfig := vpc.DefaultConfig(mockServerEndpoint, vpc.DefaultMetadataServiceVersion)
+	mockClient := vpc.NewClient(mockConfig, rest.NewClient())
+
+	// build the request using a mock profile CRN
+	req, err := vpc.NewIAMAccessTokenRequest("", mockProfileCRN, instanceIdentityToken)
+	assert.Nil(t, err)
+	assert.NotNil(t, req)
+	// validate token
+	assert.Equal(t, instanceIdentityToken, req.AccessToken)
+	// validate the request body
+	trustedProfile := req.Body
+	assert.NotNil(t, trustedProfile)
+	assert.NotNil(t, trustedProfile.CRN)
+	assert.Empty(t, trustedProfile.ID)
+	assert.Equal(t, mockProfileCRN, trustedProfile.CRN)
+	// attempt to fetch the token
+	iamToken, err := mockClient.GetIAMAccessToken(req)
+
+	assert.Nil(t, err)
+	assert.Equal(t, iamAccessToken, iamToken.AccessToken)
+	assert.Equal(t, "Bearer", iamToken.TokenType)
+	// expiry should be 1 hour in the future
+	expectedExpiry := currentTime.Unix() + 3600
+	assert.Equal(t, expectedExpiry, iamToken.Expiry.Unix())
+
+}
+
+func TestGetIAMAccessTokenFailureWProfileCRN(t *testing.T) {
+	server := startMockVPCServerForTokenExchange(t, http.StatusBadRequest, true, false, true)
+	defer server.Close()
+
+	mockServerEndpoint := server.URL
+	mockConfig := vpc.DefaultConfig(mockServerEndpoint, vpc.DefaultMetadataServiceVersion)
+	mockClient := vpc.NewClient(mockConfig, rest.NewClient())
+
+	// build the request using a mock profile CRN
+	req, err := vpc.NewIAMAccessTokenRequest("", mockProfileCRN, "")
+	assert.Nil(t, err)
+	assert.NotNil(t, req)
+	// validate token
+	assert.Empty(t, req.AccessToken)
+	// validate the request body
+	trustedProfile := req.Body
+	assert.NotNil(t, trustedProfile)
+	assert.NotNil(t, trustedProfile.CRN)
+	assert.Empty(t, trustedProfile.ID)
+	assert.Equal(t, mockProfileCRN, trustedProfile.CRN)
+	// attempt to fetch the token
+	iamToken, err := mockClient.GetIAMAccessToken(req)
+
+	assert.NotNil(t, err)
+	assert.Nil(t, iamToken)
+
+}
+
+// startMockIAMServerForCRExchange will start a mock server endpoint that supports both the
+// VPC operations for exchanging an instance identity token and an IAM TOKEN.
+func startMockVPCServerForTokenExchange(t *testing.T, statusCode int, withCRN bool, withID bool, containsBody bool) *httptest.Server {
+	// Create the mock server.
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		operationPath := req.URL.EscapedPath()
+
+		if operationPath == "/instance_identity/v1/token" {
+			// If this is an invocation of the VPC "create_access_token" operation,
+			// then validate it and then send back a good response.
+			assert.Equal(t, applicationJson, req.Header.Get("Accept"))
+			assert.Equal(t, applicationJson, req.Header.Get(contentType))
+			assert.Equal(t, "ibm", req.Header.Get(vpc.MetadataFlavor))
+			// get query params and validate
+			query := req.URL.Query()
+			version := query.Get("version")
+
+			assert.Equal(t, vpc.DefaultMetadataServiceVersion, version)
+			// validate request body
+			type createAccessTokenRequestBody struct {
+				// Time in seconds before the access token expires.
+				ExpiresIn *int64 `json:"expires_in,omitempty"`
+			}
+			// Unmarshal the request body.
+			requestBody := &createAccessTokenRequestBody{}
+			_ = json.NewDecoder(req.Body).Decode(requestBody)
+			defer req.Body.Close()
+			assert.NotNil(t, requestBody.ExpiresIn)
+
+			expiration := currentTime.Add(time.Second * 300).UTC().Format(time.RFC3339)
+			// convert expiration to valid Time.time value
+			res.WriteHeader(statusCode)
+			switch statusCode {
+			case http.StatusOK:
+				fmt.Fprintf(res, `{"access_token": "%s", "created_at": "%s", "expires_at": "%s", "expires_in": 300}`,
+					instanceIdentityToken, time.Now().String(), expiration)
+			case http.StatusBadRequest:
+				fmt.Fprintf(res, `Sorry, bad request!`)
+
+			case http.StatusUnauthorized:
+				fmt.Fprintf(res, `Sorry, you are not authorized!`)
+			}
+		} else if operationPath == "/instance_identity/v1/iam_token" {
+			// If this is an invocation of the VPC "create_iam_token" operation,
+			// then validate it and then send back a good response.
+			assert.Equal(t, applicationJson, req.Header.Get("Accept"))
+			assert.Equal(t, applicationJson, req.Header.Get(contentType))
+			authHeader := strings.TrimSpace(req.Header.Get(authorization))
+			if authHeader != "Bearer" {
+				assert.Equal(t, "Bearer "+instanceIdentityToken, req.Header.Get(authorization))
+			}
+			// get query params and validate
+			query := req.URL.Query()
+			version := query.Get("version")
+
+			assert.Equal(t, vpc.DefaultMetadataServiceVersion, version)
+			// Models the request body for the 'create_iam_token' operation.
+			type createIamTokenRequestBody struct {
+				TrustedProfile *vpc.TrustedProfileByIdOrCRN `json:"trusted_profile,omitempty"`
+			}
+			requestBody := &createIamTokenRequestBody{}
+			_ = json.NewDecoder(req.Body).Decode(requestBody)
+			defer req.Body.Close()
+
+			if withID {
+				assert.NotNil(t, requestBody.TrustedProfile.ID)
+				assert.Equal(t, mockProfileID, requestBody.TrustedProfile.ID)
+			} else if withCRN {
+				assert.NotNil(t, requestBody.TrustedProfile.CRN)
+				assert.Equal(t, mockProfileCRN, requestBody.TrustedProfile.CRN)
+			} else if !containsBody {
+				assert.NotNil(t, requestBody)
+				assert.Nil(t, requestBody.TrustedProfile)
+			}
+
+			expiration := currentTime.Add(time.Second * 3600).UTC().Format(time.RFC3339)
+			// convert expiration to valid Time.time value
+			res.WriteHeader(statusCode)
+			switch statusCode {
+			case http.StatusOK:
+				fmt.Fprintf(res, `{"access_token": "%s", "created_at": "%s", "expires_at": "%s", "expires_in": 3600}`,
+					iamAccessToken, time.Now().String(), expiration)
+			case http.StatusBadRequest:
+				fmt.Fprintf(res, `Sorry, bad request!`)
+
+			case http.StatusUnauthorized:
+				fmt.Fprintf(res, `Sorry, you are not authorized!`)
+			}
+		} else {
+			assert.Fail(t, "unknown operation path: "+operationPath)
+		}
+	}))
+	return server
+}

--- a/bluemix/configuration/core_config/bx_config.go
+++ b/bluemix/configuration/core_config/bx_config.go
@@ -29,12 +29,14 @@ type BXConfigData struct {
 	ConsolePrivateEndpoint      string
 	CloudType                   string
 	CloudName                   string
+	CRIType                     string
 	Region                      string
 	RegionID                    string
 	IAMEndpoint                 string
 	IAMPrivateEndpoint          string
 	IAMToken                    string
 	IAMRefreshToken             string
+	IsLoggedInAsCRI             bool
 	Account                     models.Account
 	Profile                     models.Profile
 	ResourceGroup               models.ResourceGroup
@@ -165,6 +167,13 @@ func (c *bxConfig) IsPrivateEndpointEnabled() (isPrivate bool) {
 	return
 }
 
+func (c *bxConfig) IsLoggedInAsCRI() (isCRI bool) {
+	c.read(func() {
+		isCRI = c.data.IsLoggedInAsCRI
+	})
+	return
+}
+
 func (c *bxConfig) HasAPIEndpoint() bool {
 	return c.APIEndpoint() != ""
 }
@@ -209,6 +218,13 @@ func (c *bxConfig) CloudName() (cname string) {
 func (c *bxConfig) CloudType() (ctype string) {
 	c.read(func() {
 		ctype = c.data.CloudType
+	})
+	return
+}
+
+func (c *bxConfig) CRIType() (criType string) {
+	c.read(func() {
+		criType = c.data.CRIType
 	})
 	return
 }
@@ -501,6 +517,18 @@ func (c *bxConfig) SetProfile(profile models.Profile) {
 	})
 }
 
+func (c *bxConfig) SetCRIType(criType string) {
+	c.write(func() {
+		c.data.CRIType = criType
+	})
+}
+
+func (c *bxConfig) SetIsLoggedInAsCRI(isCRI bool) {
+	c.write(func() {
+		c.data.IsLoggedInAsCRI = isCRI
+	})
+}
+
 func (c *bxConfig) SetResourceGroup(group models.ResourceGroup) {
 	c.write(func() {
 		c.data.ResourceGroup = group
@@ -636,6 +664,8 @@ func (c *bxConfig) ClearSession() {
 		c.data.IAMRefreshToken = ""
 		c.data.Account = models.Account{}
 		c.data.Profile = models.Profile{}
+		c.data.CRIType = ""
+		c.data.IsLoggedInAsCRI = false
 		c.data.ResourceGroup = models.ResourceGroup{}
 		c.data.LoginAt = time.Time{}
 	})

--- a/bluemix/env.go
+++ b/bluemix/env.go
@@ -21,6 +21,8 @@ var (
 	EnvCRTokenKey = newEnv("IBMCLOUD_CR_TOKEN")
 	// EnvCRProfile is the environment variable `IBMCLOUD_CR_PROFILE`
 	EnvCRProfile = newEnv("IBMCLOUD_CR_PROFILE")
+	// EnvCRVpcUrl is the environment variable `IBMCLOUD_CR_VPC_URL`
+	EnvCRVpcUrl = newEnv("IBMCLOUD_CR_VPC_URL")
 	// EnvConfigHome is the environment variable `IBMCLOUD_HOME` and `BLUEMIX_HOME` (deprecated)
 	EnvConfigHome = newEnv("IBMCLOUD_HOME", "BLUEMIX_HOME")
 	// EnvConfigDir is the environment variable `IBMCLOUD_CONFIG_HOME`

--- a/bluemix/env_test.go
+++ b/bluemix/env_test.go
@@ -29,6 +29,7 @@ func TestSet(t *testing.T) {
 	assert.Empty(t, os.Getenv("BLUEMIX_COLOR"))
 	assert.Empty(t, os.Getenv("IBMCLOUD_CR_TOKEN"))
 	assert.Empty(t, os.Getenv("IBMCLOUD_CR_PROFILE"))
+	assert.Empty(t, os.Getenv("IBMCLOUD_CR_VPC_URL"))
 	assert.Empty(t, EnvColor.Get())
 
 	EnvColor.Set("true")
@@ -38,13 +39,17 @@ func TestSet(t *testing.T) {
 
 	EnvCRTokenKey.Set("my_token")
 	EnvCRProfile.Set("my_profile")
+	EnvCRVpcUrl.Set("https://someurl.com")
 
 	assert.Equal(t, "my_token", os.Getenv("IBMCLOUD_CR_TOKEN"))
 	assert.Equal(t, "my_profile", os.Getenv("IBMCLOUD_CR_PROFILE"))
+	assert.Equal(t, "https://someurl.com", os.Getenv("IBMCLOUD_CR_VPC_URL"))
 
 	os.Unsetenv("IBMCLOUD_CR_TOKEN")
 	os.Unsetenv("IBMCLOUD_CR_PROFILE")
+	os.Unsetenv("IBMCLOUD_CR_VPC_URL")
 
 	assert.Empty(t, os.Getenv("IBMCLOUD_CR_TOKEN"))
 	assert.Empty(t, os.Getenv("IBMCLOUD_CR_PROFILE"))
+	assert.Empty(t, os.Getenv("IBMCLOUD_CR_VPC_URL"))
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -164,6 +164,13 @@ type PluginContext interface {
 	// Region returns the targeted region
 	CurrentRegion() models.Region
 
+	// CRIType returns the type of compute resource the user logged in as, if applicable. Valid values are `IKS`, `VPC`, or `OTHER`
+	CRIType() string
+
+	// VPCCRITokenURL() returns the value specified by the environment variable 'IBMCLOUD_CR_VPC_URL', if set.
+	// Otherwise, the default VPC auth url specified by the constant `DefaultServerEndpoint` is returned
+	VPCCRITokenURL() string
+
 	// HasTargetedRegion() return whether a region is targeted
 	HasTargetedRegion() bool
 
@@ -189,6 +196,9 @@ type PluginContext interface {
 
 	// IsLoggedInAsProfile returns true if a user logged into IBM Cloud using an IAM token pertaining to a trusted profile
 	IsLoggedInAsProfile() bool
+
+	// IsLoggedInAsCRI returns true if a user logged into IBM Cloud as a compute resource.
+	IsLoggedInAsCRI() bool
 
 	// IMSAccountID returns ID of the IMS account linked to the targeted BSS
 	// account

--- a/plugin/pluginfakes/fake_plugin_context.go
+++ b/plugin/pluginfakes/fake_plugin_context.go
@@ -50,6 +50,16 @@ type FakePluginContext struct {
 	cLINameReturnsOnCall map[int]struct {
 		result1 string
 	}
+	CRITypeStub        func() string
+	cRITypeMutex       sync.RWMutex
+	cRITypeArgsForCall []struct {
+	}
+	cRITypeReturns struct {
+		result1 string
+	}
+	cRITypeReturnsOnCall map[int]struct {
+		result1 string
+	}
 	CloudNameStub        func() string
 	cloudNameMutex       sync.RWMutex
 	cloudNameArgsForCall []struct {
@@ -323,6 +333,16 @@ type FakePluginContext struct {
 	isLoggedInReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	IsLoggedInAsCRIStub        func() bool
+	isLoggedInAsCRIMutex       sync.RWMutex
+	isLoggedInAsCRIArgsForCall []struct {
+	}
+	isLoggedInAsCRIReturns struct {
+		result1 bool
+	}
+	isLoggedInAsCRIReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	IsLoggedInAsProfileStub        func() bool
 	isLoggedInAsProfileMutex       sync.RWMutex
 	isLoggedInAsProfileArgsForCall []struct {
@@ -423,6 +443,16 @@ type FakePluginContext struct {
 		result1 string
 	}
 	userEmailReturnsOnCall map[int]struct {
+		result1 string
+	}
+	VPCCRITokenURLStub        func() string
+	vPCCRITokenURLMutex       sync.RWMutex
+	vPCCRITokenURLArgsForCall []struct {
+	}
+	vPCCRITokenURLReturns struct {
+		result1 string
+	}
+	vPCCRITokenURLReturnsOnCall map[int]struct {
 		result1 string
 	}
 	VersionCheckEnabledStub        func() bool
@@ -647,6 +677,59 @@ func (fake *FakePluginContext) CLINameReturnsOnCall(i int, result1 string) {
 		})
 	}
 	fake.cLINameReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakePluginContext) CRIType() string {
+	fake.cRITypeMutex.Lock()
+	ret, specificReturn := fake.cRITypeReturnsOnCall[len(fake.cRITypeArgsForCall)]
+	fake.cRITypeArgsForCall = append(fake.cRITypeArgsForCall, struct {
+	}{})
+	stub := fake.CRITypeStub
+	fakeReturns := fake.cRITypeReturns
+	fake.recordInvocation("CRIType", []interface{}{})
+	fake.cRITypeMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePluginContext) CRITypeCallCount() int {
+	fake.cRITypeMutex.RLock()
+	defer fake.cRITypeMutex.RUnlock()
+	return len(fake.cRITypeArgsForCall)
+}
+
+func (fake *FakePluginContext) CRITypeCalls(stub func() string) {
+	fake.cRITypeMutex.Lock()
+	defer fake.cRITypeMutex.Unlock()
+	fake.CRITypeStub = stub
+}
+
+func (fake *FakePluginContext) CRITypeReturns(result1 string) {
+	fake.cRITypeMutex.Lock()
+	defer fake.cRITypeMutex.Unlock()
+	fake.CRITypeStub = nil
+	fake.cRITypeReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakePluginContext) CRITypeReturnsOnCall(i int, result1 string) {
+	fake.cRITypeMutex.Lock()
+	defer fake.cRITypeMutex.Unlock()
+	fake.CRITypeStub = nil
+	if fake.cRITypeReturnsOnCall == nil {
+		fake.cRITypeReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.cRITypeReturnsOnCall[i] = struct {
 		result1 string
 	}{result1}
 }
@@ -2093,6 +2176,59 @@ func (fake *FakePluginContext) IsLoggedInReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
+func (fake *FakePluginContext) IsLoggedInAsCRI() bool {
+	fake.isLoggedInAsCRIMutex.Lock()
+	ret, specificReturn := fake.isLoggedInAsCRIReturnsOnCall[len(fake.isLoggedInAsCRIArgsForCall)]
+	fake.isLoggedInAsCRIArgsForCall = append(fake.isLoggedInAsCRIArgsForCall, struct {
+	}{})
+	stub := fake.IsLoggedInAsCRIStub
+	fakeReturns := fake.isLoggedInAsCRIReturns
+	fake.recordInvocation("IsLoggedInAsCRI", []interface{}{})
+	fake.isLoggedInAsCRIMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePluginContext) IsLoggedInAsCRICallCount() int {
+	fake.isLoggedInAsCRIMutex.RLock()
+	defer fake.isLoggedInAsCRIMutex.RUnlock()
+	return len(fake.isLoggedInAsCRIArgsForCall)
+}
+
+func (fake *FakePluginContext) IsLoggedInAsCRICalls(stub func() bool) {
+	fake.isLoggedInAsCRIMutex.Lock()
+	defer fake.isLoggedInAsCRIMutex.Unlock()
+	fake.IsLoggedInAsCRIStub = stub
+}
+
+func (fake *FakePluginContext) IsLoggedInAsCRIReturns(result1 bool) {
+	fake.isLoggedInAsCRIMutex.Lock()
+	defer fake.isLoggedInAsCRIMutex.Unlock()
+	fake.IsLoggedInAsCRIStub = nil
+	fake.isLoggedInAsCRIReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakePluginContext) IsLoggedInAsCRIReturnsOnCall(i int, result1 bool) {
+	fake.isLoggedInAsCRIMutex.Lock()
+	defer fake.isLoggedInAsCRIMutex.Unlock()
+	fake.IsLoggedInAsCRIStub = nil
+	if fake.isLoggedInAsCRIReturnsOnCall == nil {
+		fake.isLoggedInAsCRIReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.isLoggedInAsCRIReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
 func (fake *FakePluginContext) IsLoggedInAsProfile() bool {
 	fake.isLoggedInAsProfileMutex.Lock()
 	ret, specificReturn := fake.isLoggedInAsProfileReturnsOnCall[len(fake.isLoggedInAsProfileArgsForCall)]
@@ -2626,6 +2762,59 @@ func (fake *FakePluginContext) UserEmailReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
+func (fake *FakePluginContext) VPCCRITokenURL() string {
+	fake.vPCCRITokenURLMutex.Lock()
+	ret, specificReturn := fake.vPCCRITokenURLReturnsOnCall[len(fake.vPCCRITokenURLArgsForCall)]
+	fake.vPCCRITokenURLArgsForCall = append(fake.vPCCRITokenURLArgsForCall, struct {
+	}{})
+	stub := fake.VPCCRITokenURLStub
+	fakeReturns := fake.vPCCRITokenURLReturns
+	fake.recordInvocation("VPCCRITokenURL", []interface{}{})
+	fake.vPCCRITokenURLMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePluginContext) VPCCRITokenURLCallCount() int {
+	fake.vPCCRITokenURLMutex.RLock()
+	defer fake.vPCCRITokenURLMutex.RUnlock()
+	return len(fake.vPCCRITokenURLArgsForCall)
+}
+
+func (fake *FakePluginContext) VPCCRITokenURLCalls(stub func() string) {
+	fake.vPCCRITokenURLMutex.Lock()
+	defer fake.vPCCRITokenURLMutex.Unlock()
+	fake.VPCCRITokenURLStub = stub
+}
+
+func (fake *FakePluginContext) VPCCRITokenURLReturns(result1 string) {
+	fake.vPCCRITokenURLMutex.Lock()
+	defer fake.vPCCRITokenURLMutex.Unlock()
+	fake.VPCCRITokenURLStub = nil
+	fake.vPCCRITokenURLReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakePluginContext) VPCCRITokenURLReturnsOnCall(i int, result1 string) {
+	fake.vPCCRITokenURLMutex.Lock()
+	defer fake.vPCCRITokenURLMutex.Unlock()
+	fake.VPCCRITokenURLStub = nil
+	if fake.vPCCRITokenURLReturnsOnCall == nil {
+		fake.vPCCRITokenURLReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.vPCCRITokenURLReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
 func (fake *FakePluginContext) VersionCheckEnabled() bool {
 	fake.versionCheckEnabledMutex.Lock()
 	ret, specificReturn := fake.versionCheckEnabledReturnsOnCall[len(fake.versionCheckEnabledArgsForCall)]
@@ -2690,6 +2879,8 @@ func (fake *FakePluginContext) Invocations() map[string][][]interface{} {
 	defer fake.cFEEEnvIDMutex.RUnlock()
 	fake.cLINameMutex.RLock()
 	defer fake.cLINameMutex.RUnlock()
+	fake.cRITypeMutex.RLock()
+	defer fake.cRITypeMutex.RUnlock()
 	fake.cloudNameMutex.RLock()
 	defer fake.cloudNameMutex.RUnlock()
 	fake.cloudTypeMutex.RLock()
@@ -2744,6 +2935,8 @@ func (fake *FakePluginContext) Invocations() map[string][][]interface{} {
 	defer fake.iMSAccountIDMutex.RUnlock()
 	fake.isLoggedInMutex.RLock()
 	defer fake.isLoggedInMutex.RUnlock()
+	fake.isLoggedInAsCRIMutex.RLock()
+	defer fake.isLoggedInAsCRIMutex.RUnlock()
 	fake.isLoggedInAsProfileMutex.RLock()
 	defer fake.isLoggedInAsProfileMutex.RUnlock()
 	fake.isLoggedInWithServiceIDMutex.RLock()
@@ -2764,6 +2957,8 @@ func (fake *FakePluginContext) Invocations() map[string][][]interface{} {
 	defer fake.traceMutex.RUnlock()
 	fake.userEmailMutex.RLock()
 	defer fake.userEmailMutex.RUnlock()
+	fake.vPCCRITokenURLMutex.RLock()
+	defer fake.vPCCRITokenURLMutex.RUnlock()
 	fake.versionCheckEnabledMutex.RLock()
 	defer fake.versionCheckEnabledMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION
This PR adds support for a new VPC authentication method. In addition, several new methods were added to the `core_config` repository and to the `PluginContext` interface:

- `IsLoggedInAsCRI()`
- `CRIType()`
- `VPCCRITokenURL()`