### PR TITLE
feat: add support for specifying 'profile_crn' param in CRTokenRequest

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-09-16T21:05:25Z",
+  "generated_at": "2021-10-14T22:05:52Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -87,7 +87,7 @@
         "hashed_secret": "c2df5d3d760ff42f33fb38e2534d4c1b7ddde3ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 30,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -95,7 +95,7 @@
         "hashed_secret": "c287d1da815abde11f19d14ab6f9dba01f57698e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 31,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -103,7 +103,7 @@
         "hashed_secret": "41aaaaa69550b140807e70dcc170a497dbeadf0d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 33,
+        "line_number": 34,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -111,7 +111,7 @@
         "hashed_secret": "ca51a3e5092ede254e7121c4fc9fb07a0a55f2a0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 35,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -119,7 +119,7 @@
         "hashed_secret": "d327b16674fb457f595a2bc5cdbd98f8143632be",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 36,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -127,7 +127,7 @@
         "hashed_secret": "3c81615afb40d1889fc2e1fff551a8b59b4e80ce",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 36,
+        "line_number": 37,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -135,7 +135,7 @@
         "hashed_secret": "3438d9111af8058916e075b463bd7a6583cbf012",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 233,
+        "line_number": 247,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -143,7 +143,7 @@
         "hashed_secret": "53213c46677ac6f5576c44a4cbbdbe186d67cb00",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 235,
+        "line_number": 249,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -153,7 +153,7 @@
         "hashed_secret": "c8f0df25bade89c1873f5f01b85bcfb921443ac6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 20,
         "type": "JSON Web Token",
         "verified_result": null
       }

--- a/bluemix/authentication/iam/iam.go
+++ b/bluemix/authentication/iam/iam.go
@@ -21,6 +21,7 @@ const (
 	crTokenParam           = "cr_token"
 	profileIDParam         = "profile_id"
 	profileNameParam       = "profile_name"
+	profileCRNParam        = "profile_crn"
 )
 
 // Grant types
@@ -85,7 +86,17 @@ func APIKeyTokenRequest(apikey string, opts ...authentication.TokenOption) *auth
 	return r
 }
 
+// CRTokenRequest builds a 'TokenRequest' struct from the user input. The value of 'crToken' is set as the value of the 'cr_token' form
+// parameter of the request. 'profileID' and 'profileName' are optional parameters used to set the 'profile_id' and 'profile_name' form parameters
+// in the request, respectively.
 func CRTokenRequest(crToken string, profileID string, profileName string, opts ...authentication.TokenOption) *authentication.TokenRequest {
+	return CRTokenRequestWithCRN(crToken, profileID, profileName, "", opts...)
+}
+
+// CRTokenRequestWithCRN builds a 'TokenRequest' struct from the user input. The value of 'crToken' is set as the value of the 'cr_token' form
+// parameter of the request. 'profileID', 'profileName', and 'profileCRN' are optional parameters used to set the 'profile_id', 'profile_name',
+// and 'profile_crn' form parameters in the request, respectively.
+func CRTokenRequestWithCRN(crToken string, profileID string, profileName string, profileCRN string, opts ...authentication.TokenOption) *authentication.TokenRequest {
 	r := authentication.NewTokenRequest(GrantTypeCRToken)
 	r.SetTokenParam(crTokenParam, crToken)
 
@@ -94,6 +105,9 @@ func CRTokenRequest(crToken string, profileID string, profileName string, opts .
 	}
 	if profileName != "" {
 		r.SetTokenParam(profileNameParam, profileName)
+	}
+	if profileCRN != "" {
+		r.SetTokenParam(profileCRNParam, profileCRN)
 	}
 
 	for _, o := range opts {


### PR DESCRIPTION
This PR updates the iam authenticator to include a new token request method `CRTokenRequestWithCRN`. This allows building an IAM token request with the `cr_token` grant type and a new optional form parameter `profile_crn` to specify a trusted profile CRN.