### PR TITLE
fix(vpc): adjust GetInstanceIdentityToken() request body

### DIFF
--- a/bluemix/authentication/vpc/vpc.go
+++ b/bluemix/authentication/vpc/vpc.go
@@ -147,7 +147,7 @@ func (c *client) GetInstanceIdentityToken() (*InstanceIdentityToken, error) {
 	req.Query("version", c.config.Version)
 
 	// create body
-	body := fmt.Sprintf("{\"expires_in\": \"%d\"}", defaultInstanceIdentityTokenLifetime)
+	body := fmt.Sprintf("{\"expires_in\": %d}", defaultInstanceIdentityTokenLifetime)
 	req.Body(body)
 
 	var tokenResponse struct {


### PR DESCRIPTION
This PR fixes the value type that is sent in the VPC `GetInstanceIdentityToken()` request body. The `expires_in` field is an int, not a string.