### PR TITLE
fix: Handled session inactive error when getting token

### DIFF
--- a/bluemix/authentication/errors.go
+++ b/bluemix/authentication/errors.go
@@ -71,3 +71,15 @@ func (e ExternalAuthenticationError) Error() string {
 	return T("External authentication failed. Error code: {{.ErrorCode}}, message: {{.Message}}",
 		map[string]interface{}{"ErrorCode": e.ErrorCode, "Message": e.ErrorMessage})
 }
+
+type SessionInactiveError struct {
+	Description string
+}
+
+func NewSessionInactiveError(description string) *SessionInactiveError {
+	return &SessionInactiveError{Description: description}
+}
+
+func (e *SessionInactiveError) Error() string {
+	return T("Session inactive: ") + e.Description
+}

--- a/bluemix/authentication/iam/iam.go
+++ b/bluemix/authentication/iam/iam.go
@@ -45,6 +45,13 @@ const (
 	ResponseTypeDelegatedRefreshToken authentication.ResponseType = "delegated_refresh_token" // #nosec G101
 )
 
+const  (
+	InvalidTokenErrorCode           = "BXNIM0407E"
+	RefreshTokenExpiryErrorCode     = "BXNIM0408E"
+	ExternalAuthenticationErrorCode = "BXNIM0400E"
+	SessionInactiveErrorCode        = "BXNIM0439E"
+)
+
 type MFAVendor string
 
 func (m MFAVendor) String() string {
@@ -339,12 +346,14 @@ func (c *client) doRequest(r *rest.Request, respV interface{}) error {
 		if jsonErr := json.Unmarshal([]byte(err.Message), &apiErr); jsonErr == nil {
 			switch apiErr.ErrorCode {
 			case "":
-			case "BXNIM0407E":
+			case InvalidTokenErrorCode:
 				return authentication.NewInvalidTokenError(apiErr.errorMessage())
-			case "BXNIM0408E":
+			case RefreshTokenExpiryErrorCode:
 				return authentication.NewRefreshTokenExpiryError(apiErr.errorMessage())
-			case "BXNIM0400E":
+			case ExternalAuthenticationErrorCode:
 				return &authentication.ExternalAuthenticationError{ErrorCode: apiErr.Requirements.ErrorCode, ErrorMessage: apiErr.Requirements.ErrorMessage}
+			case SessionInactiveErrorCode:
+				return authentication.NewSessionInactiveError(apiErr.errorMessage())
 			default:
 				return authentication.NewServerError(err.StatusCode, apiErr.ErrorCode, apiErr.errorMessage())
 			}

--- a/bluemix/authentication/iam/iam_test.go
+++ b/bluemix/authentication/iam/iam_test.go
@@ -80,7 +80,7 @@ func TestCRTokenRequestWithProfileNameAndIDandCRN(t *testing.T) {
 }
 
 func TestGetTokenOneFromServerSuccessWithProfileID(t *testing.T) {
-	server := startMockIAMServerForCRExchange(t, 1, http.StatusOK)
+	server := startMockIAMServerForCRExchange(t, 1, http.StatusOK, "")
 	defer server.Close()
 
 	mockIAMEndpoint := server.URL
@@ -96,7 +96,7 @@ func TestGetTokenOneFromServerSuccessWithProfileID(t *testing.T) {
 }
 
 func TestGetTokenTwoFromServerSuccessWithProfileID(t *testing.T) {
-	server := startMockIAMServerForCRExchange(t, 2, http.StatusOK)
+	server := startMockIAMServerForCRExchange(t, 2, http.StatusOK, "")
 	defer server.Close()
 
 	mockIAMEndpoint := server.URL
@@ -112,7 +112,7 @@ func TestGetTokenTwoFromServerSuccessWithProfileID(t *testing.T) {
 }
 
 func TestGetTokenOneFromServerSuccessWithProfileName(t *testing.T) {
-	server := startMockIAMServerForCRExchange(t, 1, http.StatusOK)
+	server := startMockIAMServerForCRExchange(t, 1, http.StatusOK, "")
 	defer server.Close()
 
 	mockIAMEndpoint := server.URL
@@ -128,7 +128,7 @@ func TestGetTokenOneFromServerSuccessWithProfileName(t *testing.T) {
 }
 
 func TestGetTokenTwoFromServerSuccessWithProfileName(t *testing.T) {
-	server := startMockIAMServerForCRExchange(t, 2, http.StatusOK)
+	server := startMockIAMServerForCRExchange(t, 2, http.StatusOK, "")
 	defer server.Close()
 
 	mockIAMEndpoint := server.URL
@@ -144,7 +144,7 @@ func TestGetTokenTwoFromServerSuccessWithProfileName(t *testing.T) {
 }
 
 func TestGetTokenOneFromServerSuccessWithProfileCRN(t *testing.T) {
-	server := startMockIAMServerForCRExchange(t, 1, http.StatusOK)
+	server := startMockIAMServerForCRExchange(t, 1, http.StatusOK, "")
 	defer server.Close()
 
 	mockIAMEndpoint := server.URL
@@ -160,7 +160,7 @@ func TestGetTokenOneFromServerSuccessWithProfileCRN(t *testing.T) {
 }
 
 func TestGetTokenTwoFromServerSuccessWithProfileCRN(t *testing.T) {
-	server := startMockIAMServerForCRExchange(t, 2, http.StatusOK)
+	server := startMockIAMServerForCRExchange(t, 2, http.StatusOK, "")
 	defer server.Close()
 
 	mockIAMEndpoint := server.URL
@@ -176,7 +176,7 @@ func TestGetTokenTwoFromServerSuccessWithProfileCRN(t *testing.T) {
 }
 
 func TestGetTokenOneFromServerSuccessWithProfileNameAndID(t *testing.T) {
-	server := startMockIAMServerForCRExchange(t, 1, http.StatusOK)
+	server := startMockIAMServerForCRExchange(t, 1, http.StatusOK, "")
 	defer server.Close()
 
 	mockIAMEndpoint := server.URL
@@ -192,7 +192,7 @@ func TestGetTokenOneFromServerSuccessWithProfileNameAndID(t *testing.T) {
 }
 
 func TestGetTokenTwoFromServerSuccessWithProfileNameAndID(t *testing.T) {
-	server := startMockIAMServerForCRExchange(t, 2, http.StatusOK)
+	server := startMockIAMServerForCRExchange(t, 2, http.StatusOK, "")
 	defer server.Close()
 
 	mockIAMEndpoint := server.URL
@@ -208,7 +208,7 @@ func TestGetTokenTwoFromServerSuccessWithProfileNameAndID(t *testing.T) {
 }
 
 func TestGetTokenOneFromServerSuccessWithProfileNameAndIDAndCRN(t *testing.T) {
-	server := startMockIAMServerForCRExchange(t, 1, http.StatusOK)
+	server := startMockIAMServerForCRExchange(t, 1, http.StatusOK, "")
 	defer server.Close()
 
 	mockIAMEndpoint := server.URL
@@ -224,7 +224,7 @@ func TestGetTokenOneFromServerSuccessWithProfileNameAndIDAndCRN(t *testing.T) {
 }
 
 func TestGetTokenTwoFromServerSuccessWithProfileNameAndIDAndCRN(t *testing.T) {
-	server := startMockIAMServerForCRExchange(t, 2, http.StatusOK)
+	server := startMockIAMServerForCRExchange(t, 2, http.StatusOK, "")
 	defer server.Close()
 
 	mockIAMEndpoint := server.URL
@@ -240,7 +240,7 @@ func TestGetTokenTwoFromServerSuccessWithProfileNameAndIDAndCRN(t *testing.T) {
 }
 
 func TestGetTokenOneFromServerFailureWithProfileNameAndIDAndCRN(t *testing.T) {
-	server := startMockIAMServerForCRExchange(t, 1, http.StatusUnauthorized)
+	server := startMockIAMServerForCRExchange(t, 1, http.StatusUnauthorized, "")
 	defer server.Close()
 
 	mockIAMEndpoint := server.URL
@@ -256,9 +256,58 @@ func TestGetTokenOneFromServerFailureWithProfileNameAndIDAndCRN(t *testing.T) {
 	assert.Contains(t, err.Error(), "Sorry, you are not authorized!")
 }
 
+func TestGetTokenOneFromServerApiErrorWithProfileNameAndID(t *testing.T) {
+	errorCases := []struct {
+		errorCode string
+		errorMessage string
+
+	}{
+		{
+			errorCode: InvalidTokenErrorCode,
+			errorMessage: "invalid token",
+		},
+		{
+			errorCode: RefreshTokenExpiryErrorCode,
+			errorMessage: "refresh token expired",
+		},
+		{
+			errorCode: ExternalAuthenticationErrorCode,
+			errorMessage: "External authentication failed",
+		},
+		{
+			errorCode: SessionInactiveErrorCode,
+			errorMessage: "sdf",
+		},
+	}
+
+
+	for _, errorCase := range errorCases {
+		errorJson := fmt.Sprintf(`{"errorCode": "%s", "errorMessage": "%s", "errorDetails": "", "requirements": {"code": "", "error": ""}}`, errorCase.errorCode, errorCase.errorMessage)
+		server := startMockIAMServerForCRExchange(t, 1, http.StatusUnauthorized, errorJson)
+		defer server.Close()
+
+		mockIAMEndpoint := server.URL
+		mockConfig := DefaultConfig(mockIAMEndpoint)
+		mockClient := NewClient(mockConfig, rest.NewClient())
+
+		// build the request, call fetch token, and verify response
+		tokenReq := CRTokenRequestWithCRN(crAuthTestCRToken1, crAuthMockIAMProfileID, crAuthMockIAMProfileName, crAuthMockIAMProfileCRN)
+		// Force the first fetch and verify we got the first access token.
+		IAMToken, err := mockClient.GetToken(tokenReq)
+		assert.NotNil(t, err)
+		assert.Nil(t, IAMToken)
+		assert.Contains(t, err.Error(),errorCase.errorMessage)
+
+
+	}
+
+
+
+}
+
 // startMockIAMServerForCRExchange will start a mock server endpoint that supports both the
 // IAM operations that we'll need to call.
-func startMockIAMServerForCRExchange(t *testing.T, call int, statusCode int) *httptest.Server {
+func startMockIAMServerForCRExchange(t *testing.T, call int, statusCode int, errorJson string) *httptest.Server {
 	// Create the mock server.
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		operationPath := req.URL.EscapedPath()
@@ -292,15 +341,22 @@ func startMockIAMServerForCRExchange(t *testing.T, call int, statusCode int) *ht
 
 			expiration := time.Now().Unix() + 3600
 			res.WriteHeader(statusCode)
+			mockErrorJson := errorJson
 			switch statusCode {
 			case http.StatusOK:
 				fmt.Fprintf(res, `{"access_token": "%s", "token_type": "Bearer", "expires_in": 3600, "expiration": %d, "refresh_token": ""}`,
 					accessToken, expiration)
 			case http.StatusBadRequest:
-				fmt.Fprintf(res, `Sorry, bad request!`)
+				if errorJson == "" {
+					mockErrorJson = "Sorry, bad request!"
+				}
+				fmt.Fprint(res,  mockErrorJson)
 
 			case http.StatusUnauthorized:
-				fmt.Fprintf(res, `Sorry, you are not authorized!`)
+				if errorJson == "" {
+					mockErrorJson = "Sorry, you are not authorized!"
+				}
+				fmt.Fprint(res, mockErrorJson)
 			}
 		} else {
 			assert.Fail(t, "unknown operation path: "+operationPath)

--- a/i18n/resources/de_DE.all.json
+++ b/i18n/resources/de_DE.all.json
@@ -78,5 +78,9 @@
   {
     "id": "Unable to save plugin config: ",
     "translation": "Speichern der Plug-in-Konfiguration nicht möglich: "
+  },
+  {
+    "id": "Session inactive: ",
+    "translation": "Session inactive: "
   }
 ]

--- a/i18n/resources/en_US.all.json
+++ b/i18n/resources/en_US.all.json
@@ -78,5 +78,9 @@
   {
     "id": "Unable to save plugin config: ",
     "translation": "Unable to save plugin config: "
+  },
+  {
+    "id": "Session inactive: ",
+    "translation": "Session inactive: "
   }
 ]

--- a/i18n/resources/es_ES.all.json
+++ b/i18n/resources/es_ES.all.json
@@ -1,5 +1,4 @@
-[
-  {
+[ {
     "id": "\nEnter a number",
     "translation": "\nEscriba un número"
   },
@@ -78,5 +77,9 @@
   {
     "id": "Unable to save plugin config: ",
     "translation": "No se ha podido guardar la configuración del plugin:"
+  },
+  {
+    "id": "Session inactive: ",
+    "translation": "Session inactive: "
   }
 ]

--- a/i18n/resources/fr_FR.all.json
+++ b/i18n/resources/fr_FR.all.json
@@ -78,5 +78,9 @@
   {
     "id": "Unable to save plugin config: ",
     "translation": "Impossible d'enregistrer la configuration du plug-in : "
+  },
+  {
+    "id": "Session inactive: ",
+    "translation": "Session inactive: "
   }
 ]

--- a/i18n/resources/it_IT.all.json
+++ b/i18n/resources/it_IT.all.json
@@ -78,5 +78,9 @@
   {
     "id": "Unable to save plugin config: ",
     "translation": "Impossibile salvare la configurazione del plug-in: "
+  },
+  {
+    "id": "Session inactive: ",
+    "translation": "Session inactive: "
   }
 ]

--- a/i18n/resources/ja_JP.all.json
+++ b/i18n/resources/ja_JP.all.json
@@ -78,5 +78,9 @@
   {
     "id": "Unable to save plugin config: ",
     "translation": "プラグイン構成を保存できません: "
+  },
+  {
+    "id": "Session inactive: ",
+    "translation": "Session inactive: "
   }
 ]

--- a/i18n/resources/ko_KR.all.json
+++ b/i18n/resources/ko_KR.all.json
@@ -78,5 +78,9 @@
   {
     "id": "Unable to save plugin config: ",
     "translation": "플러그인 구성을 저장할 수 없음:"
+  },
+  {
+    "id": "Session inactive: ",
+    "translation": "Session inactive: "
   }
 ]

--- a/i18n/resources/pt_BR.all.json
+++ b/i18n/resources/pt_BR.all.json
@@ -78,5 +78,9 @@
   {
     "id": "Unable to save plugin config: ",
     "translation": "Não é possível salvar a configuração do plug-in: "
+  },
+  {
+    "id": "Session inactive: ",
+    "translation": "Session inactive: "
   }
 ]

--- a/i18n/resources/zh_Hans.all.json
+++ b/i18n/resources/zh_Hans.all.json
@@ -78,5 +78,9 @@
   {
     "id": "Unable to save plugin config: ",
     "translation": "无法保存插件配置："
+  },
+  {
+    "id": "Session inactive: ",
+    "translation": "Session inactive: "
   }
 ]

--- a/i18n/resources/zh_Hant.all.json
+++ b/i18n/resources/zh_Hant.all.json
@@ -78,5 +78,9 @@
   {
     "id": "Unable to save plugin config: ",
     "translation": "無法儲存外掛程式配置："
+  },
+  {
+    "id": "Session inactive: ",
+    "translation": "Session inactive: "
   }
 ]

--- a/resources/i18n_resources.go
+++ b/resources/i18n_resources.go
@@ -232,8 +232,13 @@ var _i18nResourcesEn_usAllJson = []byte(`[
   {
     "id": "Unable to save plugin config: ",
     "translation": "Unable to save plugin config: "
+  },
+  {
+    "id": "Session inactive: ",
+    "translation": "Session inactive: "
   }
-]`)
+]
+`)
 
 func i18nResourcesEn_usAllJsonBytes() ([]byte, error) {
 	return _i18nResourcesEn_usAllJson, nil


### PR DESCRIPTION
## Context
Currently, the sdk does not parse errors where the session becomes inactive when checking the token. This PR will process the session inactive error by checking the error code similar to the other errors.

**Callout: Changes replaces the literal error codes to constants to improve readability and reuse. This change does not effect existing behavior.**

## Steps to Test
### Unit Tests
1. Run the unit tests under the `bluemix` module and verify that the new tests in `iam_test.go` file pass
2. Run all unit tests and verify that all tests pass (regression)
