### PR TITLE
fix(common): Allowed empty response body for 204

### DIFF
--- a/common/rest/client.go
+++ b/common/rest/client.go
@@ -98,7 +98,11 @@ func (c *Client) DoWithContext(ctx context.Context, r *Request, respV interface{
 			} else {
 				err = yaml.NewDecoder(body).Decode(respV)
 			}
-			if err == io.EOF {
+			// For 204 No Content we should not throw an error
+			// if there is an empty response body
+			if err == io.EOF && resp.StatusCode == http.StatusNoContent {
+				err = nil
+			} else if err == io.EOF {
 				err = ErrEmptyResponseBody
 			}
 		}

--- a/common/rest/client_test.go
+++ b/common/rest/client_test.go
@@ -196,10 +196,7 @@ func TestNoContent(t *testing.T) {
 
 	var successV interface{}
 	_, err := NewClient().Do(req, &successV, nil)
-	assert.Error(err) // empty response body error
-
-	_, err = NewClient().Do(req, nil, nil)
-	assert.NoError(err)
+	assert.NoError(err) // no empty response body error
 }
 
 func TestDownloadFile(t *testing.T) {


### PR DESCRIPTION
## Context 

Currently, the rest client will return an error object if there is an empty response body. This can be a problem if the response is a 204 No Content where there may not be a response body. This PR will allow the client to return the response without an error when the status is 204

## Steps to Test

### Unit Tests
1. Run new tests in the `comment/rest` package.
2. Verify that the tests pass
