### PR TITLE
fix(gosec): address false positives

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-10-20T20:40:14Z",
+  "generated_at": "2021-11-19T19:51:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -135,7 +135,7 @@
         "hashed_secret": "3438d9111af8058916e075b463bd7a6583cbf012",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 247,
+        "line_number": 254,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -143,7 +143,7 @@
         "hashed_secret": "53213c46677ac6f5576c44a4cbbdbe186d67cb00",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 249,
+        "line_number": 256,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
   - sudo chmod o+rwx /usr/lib/python3/dist-packages/
   - python3 -m pip install -U pip
   - pip3 install --upgrade "git+https://github.com/ibm/detect-secrets.git@master#egg=detect-secrets"
+  - curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $GOPATH/bin
   - go get -u github.com/kardianos/govendor
 
 before_script:
@@ -30,3 +31,4 @@ before_script:
 
 script:
   - go test $(go list ./... | grep -v "plugin_examples" | grep -v "vendor")
+  - gosec -exclude-dir=plugin_examples -exclude-dir=vendor -quiet ./...

--- a/bluemix/authentication/iam/iam.go
+++ b/bluemix/authentication/iam/iam.go
@@ -26,8 +26,8 @@ const (
 
 // Grant types
 const (
-	GrantTypePassword              authentication.GrantType = "password" // #nosec G101
-	GrantTypeAPIKey                authentication.GrantType = "urn:ibm:params:oauth:grant-type:apikey" // #nosec G101
+	GrantTypePassword              authentication.GrantType = "password"                                 // #nosec G101
+	GrantTypeAPIKey                authentication.GrantType = "urn:ibm:params:oauth:grant-type:apikey"   // #nosec G101
 	GrantTypeOnetimePasscode       authentication.GrantType = "urn:ibm:params:oauth:grant-type:passcode" // #nosec G101
 	GrantTypeAuthorizationCode     authentication.GrantType = "authorization_code"
 	GrantTypeRefreshToken          authentication.GrantType = "refresh_token"
@@ -45,9 +45,9 @@ const (
 	ResponseTypeDelegatedRefreshToken authentication.ResponseType = "delegated_refresh_token" // #nosec G101
 )
 
-const  (
-	InvalidTokenErrorCode           = "BXNIM0407E"
-	RefreshTokenExpiryErrorCode     = "BXNIM0408E"
+const (
+	InvalidTokenErrorCode           = "BXNIM0407E" // #nosec G101
+	RefreshTokenExpiryErrorCode     = "BXNIM0408E" // #nosec G101
 	ExternalAuthenticationErrorCode = "BXNIM0400E"
 	SessionInactiveErrorCode        = "BXNIM0439E"
 )

--- a/common/downloader/file_downloader.go
+++ b/common/downloader/file_downloader.go
@@ -73,7 +73,12 @@ func (d *FileDownloader) DownloadTo(url string, outputName string) (dest string,
 	if err != nil {
 		return dest, 0, err
 	}
-	defer func() { _ = f.Close() }()
+	/* #nosec G307 */
+	defer func() {
+		if err := f.Close(); err != nil {
+			fmt.Printf("Error closing file: %s\n", err)
+		}
+	}()
 
 	var r io.Reader = resp.Body
 	if d.ProxyReader != nil {

--- a/common/file_helpers/file.go
+++ b/common/file_helpers/file.go
@@ -36,7 +36,12 @@ func CopyFile(src string, dest string) (err error) {
 	if err != nil {
 		return
 	}
-	defer func() { _ = srcFile.Close() }()
+	/* #nosec G307 */
+	defer func() {
+		if err := srcFile.Close(); err != nil {
+			fmt.Printf("Error closing file: %s\n", err)
+		}
+	}()
 
 	srcStat, err := srcFile.Stat()
 	if err != nil {
@@ -51,7 +56,12 @@ func CopyFile(src string, dest string) (err error) {
 	if err != nil {
 		return
 	}
-	defer func() { _ = destFile.Close() }()
+	/* #nosec G307 */
+	defer func() {
+		if err := destFile.Close(); err != nil {
+			fmt.Printf("Error closing file: %s\n", err)
+		}
+	}()
 
 	err = os.Chmod(dest, srcStat.Mode())
 	if err != nil {

--- a/common/file_helpers/gzip.go
+++ b/common/file_helpers/gzip.go
@@ -3,6 +3,7 @@ package file_helpers
 import (
 	"archive/tar"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -14,7 +15,12 @@ func ExtractTgz(src string, dest string) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = fd.Close() }()
+	/* #nosec G307 */
+	defer func() {
+		if err := fd.Close(); err != nil {
+			fmt.Printf("Error closing file: %s\n", err)
+		}
+	}()
 
 	gReader, err := gzip.NewReader(fd)
 	if err != nil {
@@ -62,7 +68,12 @@ func extractFileInArchive(r io.Reader, hdr *tar.Header, dest string) error {
 		if err != nil {
 			return err
 		}
-		defer func() { _ = f.Close() }()
+		/* #nosec G307 */
+		defer func() {
+			if err := f.Close(); err != nil {
+				fmt.Printf("Error closing file: %s\n", err)
+			}
+		}()
 
 		_, err = io.Copy(f, r)
 		return err


### PR DESCRIPTION
This PR adds a gosec scan to the travis build and addresses a few false positives.

The workaround for the file closer explained in https://github.com/securego/gosec/issues/512 seems to still cause a gosec failure in the latest version of gosec. The issue https://github.com/securego/gosec/issues/714 has been opened against the gosec team to provide a fix. For now, we will add a nosec flag until a proposed fix, or workaround is out.