### PR TITLE
fix(gosec): remove 'nosec G307'

### DIFF
--- a/common/downloader/file_downloader.go
+++ b/common/downloader/file_downloader.go
@@ -73,7 +73,7 @@ func (d *FileDownloader) DownloadTo(url string, outputName string) (dest string,
 	if err != nil {
 		return dest, 0, err
 	}
-	/* #nosec G307 */
+
 	defer func() {
 		if err := f.Close(); err != nil {
 			fmt.Printf("Error closing file: %s\n", err)

--- a/common/file_helpers/file.go
+++ b/common/file_helpers/file.go
@@ -36,7 +36,7 @@ func CopyFile(src string, dest string) (err error) {
 	if err != nil {
 		return
 	}
-	/* #nosec G307 */
+
 	defer func() {
 		if err := srcFile.Close(); err != nil {
 			fmt.Printf("Error closing file: %s\n", err)
@@ -56,7 +56,7 @@ func CopyFile(src string, dest string) (err error) {
 	if err != nil {
 		return
 	}
-	/* #nosec G307 */
+
 	defer func() {
 		if err := destFile.Close(); err != nil {
 			fmt.Printf("Error closing file: %s\n", err)

--- a/common/file_helpers/gzip.go
+++ b/common/file_helpers/gzip.go
@@ -15,7 +15,7 @@ func ExtractTgz(src string, dest string) error {
 	if err != nil {
 		return err
 	}
-	/* #nosec G307 */
+
 	defer func() {
 		if err := fd.Close(); err != nil {
 			fmt.Printf("Error closing file: %s\n", err)
@@ -68,7 +68,7 @@ func extractFileInArchive(r io.Reader, hdr *tar.Header, dest string) error {
 		if err != nil {
 			return err
 		}
-		/* #nosec G307 */
+
 		defer func() {
 			if err := f.Close(); err != nil {
 				fmt.Printf("Error closing file: %s\n", err)


### PR DESCRIPTION
securego/gosec#714 was fixed in the latest version of gosec (v2.9.3). We no longer need these flags.