### PR TITLE
fix: upgrade 'golang.org/x/crypto' package to address CVE-2020-29652 and CVE-2021-43565

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-12-14T23:07:42Z",
+  "generated_at": "2022-01-05T21:44:36Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -25,6 +25,7 @@
       "name": "CloudantDetector"
     },
     {
+      "ghe_instance": "github.ibm.com",
       "name": "GheDetector"
     },
     {
@@ -592,7 +593,7 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "b1b8e2bed016fd4c29f671163c35e0fb6ace2c56",
+        "hashed_secret": "8a6ce2bb8ca00141098b038b1f73f33ba1dc0090",
         "is_secret": false,
         "is_verified": false,
         "line_number": 282,
@@ -600,7 +601,7 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "6dd16f785438d21c493a2b14fb727588daabb305",
+        "hashed_secret": "44e330f0334bb3b09902c5fe7172b39fc08cf918",
         "is_secret": false,
         "is_verified": false,
         "line_number": 284,
@@ -616,15 +617,7 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "672aca7abcf09d14c312a489997e3747bf2eb370",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 300,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2a7042386a2978cfa924f0a113a62536dcc56c3a",
+        "hashed_secret": "58c75e1ff3ec1e9e0be2b9d0ba96b87a69fd2a91",
         "is_secret": false,
         "is_verified": false,
         "line_number": 302,
@@ -632,16 +625,32 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "8072f323c55a6892918a692e58cd0ac31bc7063b",
+        "hashed_secret": "672aca7abcf09d14c312a489997e3747bf2eb370",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 306,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2a7042386a2978cfa924f0a113a62536dcc56c3a",
         "is_secret": false,
         "is_verified": false,
         "line_number": 308,
         "type": "Hex High Entropy String",
         "verified_result": null
+      },
+      {
+        "hashed_secret": "8072f323c55a6892918a692e58cd0ac31bc7063b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 314,
+        "type": "Hex High Entropy String",
+        "verified_result": null
       }
     ]
   },
-  "version": "0.13.1+ibm.29.dss",
+  "version": "0.13.1+ibm.45.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -279,10 +279,10 @@
 			"revisionTime": "2015-12-08T00:24:04Z"
 		},
 		{
-			"checksumSHA1": "6U7dCaxxIMjf5V02iWgyAwppczw=",
+			"checksumSHA1": "duEcJaULRzejc7AXv+Etpn/Q/BU=",
 			"path": "golang.org/x/crypto/ssh/terminal",
-			"revision": "85f98707c97e11569271e4d9b3d397e079c4f4d0",
-			"revisionTime": "2018-03-01T00:49:11Z"
+			"revision": "5770296d904e90f15f38f77dfc2e43fdf5efc083",
+			"revisionTime": "2021-11-09T19:45:57Z"
 		},
 		{
 			"checksumSHA1": "hYsuWh8Zj6z+8rFsK7F7mABIR44=",
@@ -295,6 +295,12 @@
 			"path": "golang.org/x/sys/windows",
 			"revision": "349b81fb5c64ec1734eb6ee148df25459ea48517",
 			"revisionTime": "2018-03-08T02:43:59Z"
+		},
+		{
+			"checksumSHA1": "LGa6RbqU39O0hcVKITo0zDIK5p0=",
+			"path": "golang.org/x/term",
+			"revision": "d7a72108b828bad153e6ec11c4ac4793f792ee6f",
+			"revisionTime": "2020-09-30T12:49:57Z"
 		},
 		{
 			"checksumSHA1": "raBtsDwCvkqXSCQI0GHcVAXoOSc=",


### PR DESCRIPTION
This PR addresses [CVE-2021-43565 ](https://www.whitesourcesoftware.com/vulnerability-database/CVE-2021-43565) and  [CVE-2020-29652](https://www.whitesourcesoftware.com/vulnerability-database/CVE-2020-29652). The `golang.org/x/crypto` package was upgraded to `v0.0.0-20201216223049-8b5274cf687f` which contains both fixes.

Full diff: https://github.com/golang/crypto/compare/85f98707c97e11569271e4d9b3d397e079c4f4d0...5770296d904e

These CVEs seems to be unique to the `golang.org/x/crypto` package and not the `golang.org/x/crypto/ssh/terminal` package which is all the SDK uses. So the blast radius of this is smaller than what the full diff shows.