### PR TITLE
Adds PrintJson to bluemix/terminal/table

### DIFF
--- a/bluemix/terminal/table_test.go
+++ b/bluemix/terminal/table_test.go
@@ -1,0 +1,93 @@
+package terminal_test
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"testing"
+
+	. "github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/terminal"
+)
+
+// Happy path testing
+func TestPrintTableSimple(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{"test1", "test2"})
+	testTable.Add("row1", "row2")
+	testTable.Print()
+	assert.Contains(t, buf.String(), "test2")
+	assert.Contains(t, buf.String(), "row1")
+	assert.Equal(t, buf.String(), "test1   test2   \nrow1    row2   \n")
+}
+
+func TestPrintTableJson(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{"test1", "test2"})
+	testTable.Add("row1-col1", "row1-col2")
+	testTable.Add("row2-col1", "row2-col2")
+	testTable.PrintJson()
+	assert.Contains(t, buf.String(), "\"test1\": \"row1-col1\"")
+	assert.Contains(t, buf.String(), "\"test2\": \"row2-col2\"")
+}
+
+// Blank headers
+func TestEmptyHeaderTable(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{"", ""})
+	testTable.Add("row1", "row2")
+	testTable.Print()
+	assert.Contains(t, buf.String(), "row1")
+	assert.Equal(t, buf.String(), "          \nrow1   row2   \n")
+}
+
+func TestEmptyHeaderTableJson(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{"", ""})
+	testTable.Add("row1", "row2")
+	testTable.PrintJson()
+	assert.Contains(t, buf.String(), "\"column_2\": \"row2\"")
+	assert.Contains(t, buf.String(), "\"column_1\": \"row1\"")
+}
+
+// Empty Headers / More rows than headers
+func TestZeroHeadersTable(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{})
+	testTable.Add("row1", "row2")
+	testTable.Print()
+	assert.Contains(t, buf.String(), "row1")
+	assert.Equal(t, buf.String(), "\nrow1   row2   \n")
+}
+
+func TestZeroHeadersTableJson(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{})
+	testTable.Add("row1", "row2")
+	testTable.PrintJson()
+	assert.Contains(t, buf.String(), "row1")
+	assert.Contains(t, buf.String(), "\"column_2\": \"row2\"")
+	assert.Contains(t, buf.String(), "\"column_1\": \"row1\"")
+}
+
+// Empty rows / More headers than rows
+
+func TestNotEnoughRowEntires(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{"col1", "col2"})
+	testTable.Add("row1")
+	testTable.Add("", "row2")
+	testTable.Print()
+	assert.Contains(t, buf.String(), "row1")
+	assert.Equal(t, buf.String(), "col1   col2   \nrow1   \n       row2   \n")
+}
+
+func TestNotEnoughRowEntiresJson(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{})
+	testTable.Add("row1")
+	testTable.Add("", "row2")
+	testTable.PrintJson()
+	assert.Contains(t, buf.String(), "row1")
+	assert.Contains(t, buf.String(), "\"column_2\": \"row2\"")
+	assert.Contains(t, buf.String(), "\"column_1\": \"row1\"")
+	assert.Contains(t, buf.String(), "\"column_1\": \"\"")
+}

--- a/common/file_helpers/file.go
+++ b/common/file_helpers/file.go
@@ -52,6 +52,7 @@ func CopyFile(src string, dest string) (err error) {
 		return fmt.Errorf("%s is not a regular file.", src)
 	}
 
+	//#nosec G304 -- This is a false positive
 	destFile, err := os.Create(dest)
 	if err != nil {
 		return

--- a/common/file_helpers/gzip.go
+++ b/common/file_helpers/gzip.go
@@ -64,6 +64,7 @@ func extractFileInArchive(r io.Reader, hdr *tar.Header, dest string) error {
 			return err
 		}
 
+		//#nosec G304 -- This is a false positive
 		f, err := os.Create(path)
 		if err != nil {
 			return err


### PR DESCRIPTION
I use this table library a lot in the `ibmcloud sl` plugin, and it would be nice to have a way to simply print the table as a JSON string. Currently my only option is to print the raw data that went into the table originally, which might not match up exactly with what I want to show the user.

My approach here was to just render the table as an array, each row being an object with each property matching a column in the table.

For example
```go
	testTable := NewTable(&buf, []string{"test1", "test2"})
	testTable.Add("row1-col1", "row1-col2")
	testTable.Add("row2-col1", "row2-col2")
	testTable.PrintJson()
```
would render something like this:

```json
[
        {
                "test1": "row1-col1",
                "test2": "row1-col2"
        },
        {
                "test1": "row2-col1",
                "test2": "row2-col2"
        }
]
```