### PR TITLE
docs: Added how to use test doubles in guide

### DIFF
--- a/docs/plugin_developer_guide.md
+++ b/docs/plugin_developer_guide.md
@@ -1067,7 +1067,7 @@ When writing unit tests you may need to mock parts of the cli-sdk, dev-plugin, o
 You can use the fakes implementation to mock the return, arguments, etc. Below are a few example of showing how to stub various methods in [PluginContext](https://github.com/IBM-Cloud/ibm-cloud-cli-sdk/blob/master/plugin/plugin_context.go) and [PluginConfig](https://github.com/IBM-Cloud/ibm-cloud-cli-sdk/blob/master/plugin/plugin_config.go).
 
 
-```
+```go
 import (
   "github.com/IBM-Cloud/ibm-cloud-cli-sdk/plugin/pluginfakes"
 )
@@ -1102,7 +1102,7 @@ It("should call RefreshToken more than once", func() {
 
 ```
 
-You can find other examples in the [tests](https://github.com/maxbrunsfeld/counterfeiter/blob/master/generated_fakes_test.go) found in counterfeiter.
+You can find other examples in [tests](https://github.com/maxbrunsfeld/counterfeiter/blob/master/generated_fakes_test.go) found in counterfeiter.
 
 ## 7. Globalization
 

--- a/docs/plugin_developer_guide.md
+++ b/docs/plugin_developer_guide.md
@@ -1076,7 +1076,7 @@ var (
   config  *pluginfakes.FakePluginConfig
 )
 
-BeforeEach(() => {
+BeforeEach(func() {
   context = new(pluginfakes.FakePluginContext)
   config = new(pluginfakes.FakePluginConfig)
 

--- a/docs/plugin_developer_guide.md
+++ b/docs/plugin_developer_guide.md
@@ -1062,9 +1062,9 @@ func TestStart() {
 
 ### 6.1 Using the Test Doubles
 
-When writing unit tests you may need to mock parts of the cli-sdk, dev-plugin, or your own interfaces. The dev-plug uses [counterfeiter](https://github.com/maxbrunsfeld/counterfeiter) to mock interfaces that allow you to fake their implementation.
+When writing unit tests you may need to mock parts of the cli-sdk, dev-plugin, or your own interfaces. The dev-plugin uses [counterfeiter](https://github.com/maxbrunsfeld/counterfeiter) to mock interfaces that allow you to fake their implementation.
 
-You can use the fakes implementation to mock the return, arguments, etc. Below are a few example of showing how to stub various methods in [PluginContext](https://github.com/IBM-Cloud/ibm-cloud-cli-sdk/blob/master/plugin/plugin_context.go)
+You can use the fakes implementation to mock the return, arguments, etc. Below are a few example of showing how to stub various methods in [PluginContext](https://github.com/IBM-Cloud/ibm-cloud-cli-sdk/blob/master/plugin/plugin_context.go) and [PluginConfig](https://github.com/IBM-Cloud/ibm-cloud-cli-sdk/blob/master/plugin/plugin_config.go)
 
 
 ```

--- a/docs/plugin_developer_guide.md
+++ b/docs/plugin_developer_guide.md
@@ -1060,6 +1060,50 @@ func TestStart() {
 }
 ```
 
+### 6.1 Using the Test Doubles
+
+When writing unit tests you may need to mock parts of the cli-sdk, dev-plugin, or your own interfaces. The dev-plug uses [counterfeiter](https://github.com/maxbrunsfeld/counterfeiter) to mock interfaces that allow you to fake their implementation.
+
+You can use the fakes implementation to mock the return, arguments, etc. Below are a few example of showing how to stub various methods in [PluginContext](https://github.com/IBM-Cloud/ibm-cloud-cli-sdk/blob/master/plugin/plugin_context.go)
+
+
+```
+import (
+  "github.com/IBM-Cloud/ibm-cloud-cli-sdk/plugin/pluginfakes"
+)
+var (
+  context *pluginfakes.FakePluginContext
+  config  *pluginfakes.FakePluginConfig
+)
+
+BeforeEach(() => {
+  context = new(pluginfakes.FakePluginContext)
+  config = new(pluginfakes.FakePluginConfig)
+
+  // mock the IsLoggedIn method to always return true
+  // NOTE: expect method signature format to be `<METHOD_NAME>Returns()`
+  context.IsLoggedInReturns(true)
+
+  // mock the second IsLoggedIn call return false
+  // NOTE: expect method signature format to be `<METHOD_NAME>ReturnsOnCall()`
+  context.IsLoggedInReturnsOnCall(1, false)
+
+  // stub the arguments for the first PluginConfig.Set method
+  // NOTE: expect method signature format to be `<METHOD_NAME>ArgsForCall(...args)`
+  config.SetArgsForCall("region", "us-south")
+})
+
+It("should call RefreshToken more than once", func() {
+
+  // return the number of times a method is called
+  // NOTE: expect method signature format to be `<METHOD_NAME>Calls()`
+  Expect(context.RefreshIAMTokenCalls()).Should(BeNumerically(">", 0))
+})
+
+```
+
+You can find other examples in the [tests](https://github.com/maxbrunsfeld/counterfeiter/blob/master/generated_fakes_test.go) found in counterfeiter
+
 ## 7. Globalization
 
 IBM Cloud CLI tends to be used globally. Both IBM Cloud CLI and its plug-ins should support globalization. We have enabled internationalization (i18n) for CLI's base commands with the help of the third-party tool "[go-i18n](https://github.com/nicksnyder/go-i18n)". To keep user experience consistent, we recommend plug-in developers follow the CLI's way of i18n enablement.

--- a/docs/plugin_developer_guide.md
+++ b/docs/plugin_developer_guide.md
@@ -1064,7 +1064,7 @@ func TestStart() {
 
 When writing unit tests you may need to mock parts of the cli-sdk, dev-plugin, or your own interfaces. The dev-plugin uses [counterfeiter](https://github.com/maxbrunsfeld/counterfeiter) to mock interfaces that allow you to fake their implementation.
 
-You can use the fakes implementation to mock the return, arguments, etc. Below are a few example of showing how to stub various methods in [PluginContext](https://github.com/IBM-Cloud/ibm-cloud-cli-sdk/blob/master/plugin/plugin_context.go) and [PluginConfig](https://github.com/IBM-Cloud/ibm-cloud-cli-sdk/blob/master/plugin/plugin_config.go)
+You can use the fakes implementation to mock the return, arguments, etc. Below are a few example of showing how to stub various methods in [PluginContext](https://github.com/IBM-Cloud/ibm-cloud-cli-sdk/blob/master/plugin/plugin_context.go) and [PluginConfig](https://github.com/IBM-Cloud/ibm-cloud-cli-sdk/blob/master/plugin/plugin_config.go).
 
 
 ```
@@ -1102,7 +1102,7 @@ It("should call RefreshToken more than once", func() {
 
 ```
 
-You can find other examples in the [tests](https://github.com/maxbrunsfeld/counterfeiter/blob/master/generated_fakes_test.go) found in counterfeiter
+You can find other examples in the [tests](https://github.com/maxbrunsfeld/counterfeiter/blob/master/generated_fakes_test.go) found in counterfeiter.
 
 ## 7. Globalization
 


### PR DESCRIPTION
# Context

This PR will add a new sub section under **Utility for Unit Testing** section. This new section will explain how to use use the test doubles provided by the fake interfaces generated by `counterfeiter`. There are also examples on how to use some of the widely used test double methods
