### PR TITLE
fix(auth): Updated vpc service version

### DIFF
--- a/bluemix/authentication/vpc/vpc.go
+++ b/bluemix/authentication/vpc/vpc.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	DefaultMetadataServiceVersion = "2021-09-30"
+	DefaultMetadataServiceVersion = "2022-06-30"
 	DefaultServerEndpoint         = "http://169.254.169.254"
 
 	defaultMetadataFlavor                 = "ibm"


### PR DESCRIPTION
# Context

The PR will update the VPC service version to allow VPC authentication

# Steps to Test
1. Download CLI-SDK from this PR into local CLI: `go get github.com/IBM-Cloud/ibm-cloud-cli-sdk@d8a884dadc543de917266dc6b67a3f7608bf94e3`
2. Build CLI
3. Enable verbose logging: `ibmcloud config --trace true`
4. Run the command `ibmcloud login --vpc-cri`
5. Verify that the error `invalid_version_range` does not get returned
