### PR TITLE
feat(plugin): Added meta flag to detect if cobra plugin

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -34,6 +34,9 @@ type PluginMetadata struct {
 
 	// Whether the plugin supports private endpoint access via VPC
 	IsAccessFromVPC bool
+
+	// Whether the plugin was built using Cobra
+	IsCobraPlugin bool
 }
 
 func (p PluginMetadata) NameAndAliases() []string {

--- a/plugin_examples/list_plugin/plugin.go
+++ b/plugin_examples/list_plugin/plugin.go
@@ -22,8 +22,7 @@ type ListPlugin struct{}
 
 func (p *ListPlugin) GetMetadata() plugin.PluginMetadata {
 	return plugin.PluginMetadata{
-		Name:          "ibmcloud-list",
-		IsCobraPlugin: true,
+		Name: "ibmcloud-list",
 		Version: plugin.VersionType{
 			Major: 0,
 			Minor: 0,

--- a/plugin_examples/list_plugin/plugin.go
+++ b/plugin_examples/list_plugin/plugin.go
@@ -22,7 +22,8 @@ type ListPlugin struct{}
 
 func (p *ListPlugin) GetMetadata() plugin.PluginMetadata {
 	return plugin.PluginMetadata{
-		Name: "ibmcloud-list",
+		Name:          "ibmcloud-list",
+		IsCobraPlugin: true,
 		Version: plugin.VersionType{
 			Major: 0,
 			Minor: 0,


### PR DESCRIPTION
# Context

This PR will add a boolean metadata flag `IsCobraPlugin` to determine if a plugin created using the cobra framework. This metadata flag will fix some of the computed metadata used in generating the usage help text between plugins created by urfave and cobra.
