### PR TITLE
feat(auth): Added LastSessionUpdateTime config

### DIFF
--- a/bluemix/authentication/iam/iam.go
+++ b/bluemix/authentication/iam/iam.go
@@ -318,7 +318,7 @@ func (c *client) GetToken(tokenReq *authentication.TokenRequest) (*Token, error)
 	return &ret, nil
 }
 
-// Refresh maintains the session state. Useful for async workloads
+// RefreshSession maintains the session state. Useful for async workloads
 // @param sessionID string - the session ID
 func (c *client) RefreshSession(sessionID string) error {
 	// If no session ID is provided there is no need to refresh

--- a/bluemix/configuration/core_config/bx_config.go
+++ b/bluemix/configuration/core_config/bx_config.go
@@ -50,6 +50,7 @@ type BXConfigData struct {
 	SSLDisabled                 bool
 	Locale                      string
 	MessageOfTheDayTime         int64
+	LastSessionUpdateTime       int64
 	Trace                       string
 	ColorEnabled                string
 	HTTPTimeout                 int
@@ -725,6 +726,20 @@ func (c *bxConfig) SetMessageOfTheDayTime() {
 	c.write(func() {
 		c.data.MessageOfTheDayTime = time.Now().Unix()
 	})
+}
+
+func (c *bxConfig) SetLastSessionUpdateTime() {
+	c.write(func() {
+		c.data.LastSessionUpdateTime = time.Now().Unix()
+	})
+}
+
+func (c *bxConfig) LastSessionUpdateTime() (session int64) {
+	c.read(func() {
+		session = c.data.LastSessionUpdateTime
+	})
+
+	return
 }
 
 func (c *bxConfig) ClearSession() {

--- a/bluemix/configuration/core_config/bx_config_test.go
+++ b/bluemix/configuration/core_config/bx_config_test.go
@@ -464,7 +464,9 @@ func TestLastUpdateSessionTime(t *testing.T) {
 	// Set last session update time and check that the timestamp is set
 	config.SetLastSessionUpdateTime()
 
-	assert.NotEmpty(t, config.LastSessionUpdateTime())
+	// Best effort to check session time was just updated (delta ~1min)
+	assert.WithinDuration(t, time.Now(), time.Unix(config.LastSessionUpdateTime(), 0), 60*time.Second)
+
 }
 
 func checkUsageStats(enabled bool, timeStampExist bool, config core_config.Repository, t *testing.T) {

--- a/bluemix/configuration/core_config/bx_config_test.go
+++ b/bluemix/configuration/core_config/bx_config_test.go
@@ -454,6 +454,19 @@ func TestMOD(t *testing.T) {
 	t.Cleanup(cleanupConfigFiles)
 }
 
+func TestLastUpdateSessionTime(t *testing.T) {
+
+	config := prepareConfigForCLI(`{}`, t)
+
+	// check initial state
+	assert.Empty(t, config.LastSessionUpdateTime())
+
+	// Set last session update time and check that the timestamp is set
+	config.SetLastSessionUpdateTime()
+
+	assert.NotEmpty(t, config.LastSessionUpdateTime())
+}
+
 func checkUsageStats(enabled bool, timeStampExist bool, config core_config.Repository, t *testing.T) {
 	assert.Equal(t, config.UsageStatsEnabled(), enabled)
 	assert.Equal(t, config.UsageStatsEnabledLastUpdate().IsZero(), !timeStampExist)

--- a/bluemix/configuration/core_config/repository.go
+++ b/bluemix/configuration/core_config/repository.go
@@ -122,6 +122,9 @@ type Repository interface {
 
 	CheckMessageOfTheDay() bool
 	SetMessageOfTheDayTime()
+
+	SetLastSessionUpdateTime()
+	LastSessionUpdateTime() (session int64)
 }
 
 // Deprecated
@@ -266,6 +269,8 @@ func (c repository) RefreshIAMToken() (string, error) {
 		c.SetIAMRefreshToken(token.RefreshToken)
 	}
 
+	c.SetLastSessionUpdateTime()
+
 	return ret, nil
 }
 
@@ -353,6 +358,14 @@ func (c repository) UnsetAPI() {
 func (c repository) ClearSession() {
 	c.bxConfig.ClearSession()
 	c.cfConfig.ClearSession()
+}
+
+func (c repository) LastSessionUpdateTime() (session int64) {
+	return c.bxConfig.LastSessionUpdateTime()
+}
+
+func (c repository) SetLastSessionUpdateTime() {
+	c.bxConfig.SetLastSessionUpdateTime()
 }
 
 func NewCoreConfig(errHandler func(error)) ReadWriter {

--- a/docs/plugin_developer_guide.md
+++ b/docs/plugin_developer_guide.md
@@ -963,7 +963,6 @@ accessToken := token.AccessToken
 newRefreshToken := token.RefreshToken
 
 // optional, set access token and refresh token back to config
-
 config.SetAccessToken(accessToken)
 config.SetRefreshToken(newRefreshToken)
 
@@ -975,7 +974,7 @@ client.RefreshSession(token)
 ### 5.3 VPC Compute Resource Identity Authentication
 
 #### 5.3.1 Get the IAM Access Token
-The IBM CLoud CLI supports logging in as a VPC compute resource identity. The CLI will fetch a VPC instance identity token and exchange it for an IAM access token when logging in as a VPC compute resource identity. This access token is stored in configuration once a user successfully logs into the CLI.
+The IBM Cloud CLI supports logging in as a VPC compute resource identity. The CLI will fetch a VPC instance identity token and exchange it for an IAM access token when logging in as a VPC compute resource identity. This access token is stored in configuration once a user successfully logs into the CLI.
 
 Plug-ins can invoke `plugin.PluginContext.IsLoggedInAsCRI()` and `plugin.PluginContext.CRIType()` in the CLI SDK to detect whether the user has logged in as a VPC compute resource identity.
 You can get the IAM access token resulting from the user logging in as a VPC compute resource identity from the IBM CLoud SDK as follows:

--- a/docs/plugin_developer_guide.md
+++ b/docs/plugin_developer_guide.md
@@ -966,6 +966,10 @@ newRefreshToken := token.RefreshToken
 
 config.SetAccessToken(accessToken)
 config.SetRefreshToken(newRefreshToken)
+
+// optional, maintain session for long running workloads
+request = iam.RefreshSessionRequest(token)
+client.RefreshSession(token)
 ```
 
 ### 5.3 VPC Compute Resource Identity Authentication


### PR DESCRIPTION
# Context

This PR will add a new config property called `LastSessionUpdateTime` which will keep track of the last time the session was updated. The config property will be set to the current timestamp. The property will be set on login, refresh token, and after each CLI command has been executed

Also, a new method called `RefreshSession` is added to allow refreshing the current session. This is primarily used to maintain session when running long running commands from the CLI 

# Callouts
- The `RefreshSession` method and `LastSessionUpdateTime` only applies to IAM tokens.

# Steps to Test

## Unit Tests
1. Change directory to the root of the local repo 
2. Run the command: `go test -v -count=1 ./bluemix/authentication/iam`
3. Verify that all tests have passed


