### PR TITLE
fix: Used messageID as translation if translation cannot be found

### DIFF
--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -20,10 +20,9 @@ const (
 )
 
 var (
-	bundle                *i18n.Bundle
-	T                     TranslateFunc
-	RESOURCE_PATH         = filepath.Join("i18n", "resources")
-	TRANSLATION_NOT_FOUND = "!!i18N_MESSAGE_NOT_FOUND!!"
+	bundle        *i18n.Bundle
+	T             TranslateFunc
+	RESOURCE_PATH = filepath.Join("i18n", "resources")
 )
 
 func init() {
@@ -83,9 +82,9 @@ func Translate(loc *i18n.Localizer) TranslateFunc {
 
 		// If no message is returned we can assume that that
 		// the translation could not be found in any of the files
-		// Set the message as !!i18N_MESSAGE_NOT_FOUND!!
+		// Set the message as the messageID
 		if msg == "" {
-			msg = TRANSLATION_NOT_FOUND
+			msg = messageId
 		}
 		return msg
 

--- a/plugin_examples/list_plugin/commands/list_test.go
+++ b/plugin_examples/list_plugin/commands/list_test.go
@@ -2,7 +2,6 @@ package commands_test
 
 import (
 	sdkmodels "github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/models"
-	"github.com/IBM-Cloud/ibm-cloud-cli-sdk/i18n"
 	"github.com/IBM-Cloud/ibm-cloud-cli-sdk/plugin/pluginfakes"
 	"github.com/IBM-Cloud/ibm-cloud-cli-sdk/plugin_examples/list_plugin/api/fakes"
 	. "github.com/IBM-Cloud/ibm-cloud-cli-sdk/plugin_examples/list_plugin/commands"
@@ -46,7 +45,7 @@ var _ = Describe("ListCommand", func() {
 			It("Should fail", func() {
 				err = cmd.Run([]string{})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal(i18n.TRANSLATION_NOT_FOUND))
+				Expect(err.Error()).To(Equal("No CF API endpoint set. Use '{{.Command}}' to target a CloudFoundry environment."))
 			})
 		})
 	})


### PR DESCRIPTION
The purpose of this ticket to use the messageID as the translation if the translation cannot be found in the language files
