### PR TITLE
Adds PrintCsv() function and unit tests to bluemix/terminal/table

### DIFF
--- a/bluemix/terminal/table.go
+++ b/bluemix/terminal/table.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"encoding/csv"
 	"fmt"
 	"io"
 	"strings"
@@ -18,6 +19,7 @@ type Table interface {
 	Add(row ...string)
 	Print()
 	PrintJson()
+	PrintCsv()
 }
 
 type PrintableTable struct {
@@ -156,4 +158,10 @@ func (t *PrintableTable) PrintJson() {
 	fmt.Fprintln(t.writer, "]")
 	// mimic behavior of Print()
 	t.rows = [][]string{}
+}
+
+func (t *PrintableTable) PrintCsv() {
+	csvwriter := csv.NewWriter(t.writer)
+	csvwriter.Write(t.headers)
+	csvwriter.WriteAll(t.rows)
 }

--- a/bluemix/terminal/table.go
+++ b/bluemix/terminal/table.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 
+	. "github.com/IBM-Cloud/ibm-cloud-cli-sdk/i18n"
 	"github.com/mattn/go-runewidth"
 )
 
@@ -19,7 +20,7 @@ type Table interface {
 	Add(row ...string)
 	Print()
 	PrintJson()
-	PrintCsv()
+	PrintCsv() error
 }
 
 type PrintableTable struct {
@@ -160,14 +161,15 @@ func (t *PrintableTable) PrintJson() {
 	t.rows = [][]string{}
 }
 
-func (t *PrintableTable) PrintCsv() {
+func (t *PrintableTable) PrintCsv() error {
 	csvwriter := csv.NewWriter(t.writer)
 	err := csvwriter.Write(t.headers)
 	if err != nil {
-		fmt.Fprintln(t.writer, "Failed, header could not convert to csv format")
+		return fmt.Errorf(T("Failed, header could not convert to csv format"), err.Error())
 	}
 	err = csvwriter.WriteAll(t.rows)
 	if err != nil {
-		fmt.Fprintln(t.writer, "Failed, rows could not convert to csv format")
+		return fmt.Errorf(T("Failed, rows could not convert to csv format"), err.Error())
 	}
+	return nil
 }

--- a/bluemix/terminal/table.go
+++ b/bluemix/terminal/table.go
@@ -162,6 +162,12 @@ func (t *PrintableTable) PrintJson() {
 
 func (t *PrintableTable) PrintCsv() {
 	csvwriter := csv.NewWriter(t.writer)
-	csvwriter.Write(t.headers)
-	csvwriter.WriteAll(t.rows)
+	err := csvwriter.Write(t.headers)
+	if err != nil {
+		fmt.Fprintln(t.writer, "Failed, header could not convert to csv format")
+	}
+	err = csvwriter.WriteAll(t.rows)
+	if err != nil {
+		fmt.Fprintln(t.writer, "Failed, rows could not convert to csv format")
+	}
 }

--- a/bluemix/terminal/table_test.go
+++ b/bluemix/terminal/table_test.go
@@ -99,7 +99,8 @@ func TestPrintCsvSimple(t *testing.T) {
 	testTable := NewTable(&buf, []string{"col1", "col2"})
 	testTable.Add("row1-col1", "row1-col2")
 	testTable.Add("row2-col1", "row2-col2")
-	testTable.PrintCsv()
+	err := testTable.PrintCsv()
+	assert.Equal(t, err, nil)
 	assert.Contains(t, buf.String(), "col1,col2")
 	assert.Contains(t, buf.String(), "row1-col1,row1-col2")
 	assert.Contains(t, buf.String(), "row2-col1,row2-col2")
@@ -110,7 +111,8 @@ func TestNotEnoughColPrintCsv(t *testing.T) {
 	testTable := NewTable(&buf, []string{"", "col2"})
 	testTable.Add("row1-col1", "row1-col2")
 	testTable.Add("row2-col1", "row2-col2")
-	testTable.PrintCsv()
+	err := testTable.PrintCsv()
+	assert.Equal(t, err, nil)
 	assert.Contains(t, buf.String(), ",col2")
 	assert.Contains(t, buf.String(), "row1-col1,row1-col2")
 	assert.Contains(t, buf.String(), "row2-col1,row2-col2")
@@ -121,7 +123,8 @@ func TestNotEnoughRowPrintCsv(t *testing.T) {
 	testTable := NewTable(&buf, []string{"col1", "col2"})
 	testTable.Add("row1-col1", "row1-col2")
 	testTable.Add("row2-col1", "")
-	testTable.PrintCsv()
+	err := testTable.PrintCsv()
+	assert.Equal(t, err, nil)
 	assert.Contains(t, buf.String(), "col1,col2")
 	assert.Contains(t, buf.String(), "row1-col1,row1-col2")
 	assert.Contains(t, buf.String(), "row2-col1,")
@@ -130,6 +133,7 @@ func TestNotEnoughRowPrintCsv(t *testing.T) {
 func TestEmptyTable(t *testing.T) {
 	buf := bytes.Buffer{}
 	testTable := NewTable(&buf, []string{})
-	testTable.PrintCsv()
+	err := testTable.PrintCsv()
+	assert.Equal(t, err, nil)
 	assert.Equal(t, len(strings.TrimSpace(buf.String())), 0)
 }

--- a/bluemix/terminal/table_test.go
+++ b/bluemix/terminal/table_test.go
@@ -92,3 +92,36 @@ func TestNotEnoughRowEntiresJson(t *testing.T) {
 	assert.Contains(t, buf.String(), "\"column_1\": \"row1\"")
 	assert.Contains(t, buf.String(), "\"column_1\": \"\"")
 }
+
+func TestPrintCsvSimple(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{"col1", "col2"})
+	testTable.Add("row1-col1", "row1-col2")
+	testTable.Add("row2-col1", "row2-col2")
+	testTable.PrintCsv()
+	assert.Contains(t, buf.String(), "col1,col2")
+	assert.Contains(t, buf.String(), "row1-col1,row1-col2")
+	assert.Contains(t, buf.String(), "row2-col1,row2-col2")
+}
+
+func TestNotEnoughColPrintCsv(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{"", "col2"})
+	testTable.Add("row1-col1", "row1-col2")
+	testTable.Add("row2-col1", "row2-col2")
+	testTable.PrintCsv()
+	assert.Contains(t, buf.String(), ",col2")
+	assert.Contains(t, buf.String(), "row1-col1,row1-col2")
+	assert.Contains(t, buf.String(), "row2-col1,row2-col2")
+}
+
+func TestNotEnoughRowPrintCsv(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{"col1", "col2"})
+	testTable.Add("row1-col1", "row1-col2")
+	testTable.Add("row2-col1", "")
+	testTable.PrintCsv()
+	assert.Contains(t, buf.String(), "col1,col2")
+	assert.Contains(t, buf.String(), "row1-col1,row1-col2")
+	assert.Contains(t, buf.String(), "row2-col1,")
+}

--- a/bluemix/terminal/table_test.go
+++ b/bluemix/terminal/table_test.go
@@ -2,6 +2,7 @@ package terminal_test
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -124,4 +125,11 @@ func TestNotEnoughRowPrintCsv(t *testing.T) {
 	assert.Contains(t, buf.String(), "col1,col2")
 	assert.Contains(t, buf.String(), "row1-col1,row1-col2")
 	assert.Contains(t, buf.String(), "row2-col1,")
+}
+
+func TestEmptyTable(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{})
+	testTable.PrintCsv()
+	assert.Equal(t, len(strings.TrimSpace(buf.String())), 0)
 }


### PR DESCRIPTION
I would like to add a new format to represent the tables in `ibmcloud sl` where we use them a lot, print in csv format

Using the same format
```go
testTable := NewTable(&buf, []string{"col1", "col2"})
testTable.Add("row1-col1", "row1-col2")
testTable.Add("row2-col1", "row2-col2")
testTable.PrintCsv()
```
The output would look like this
```
col1,col2
row1-col1,row1-col2
row2-col1,row2-col2
```