### PR TITLE
docs: Added details on plugin name and plugin alias standards in guide

### DIFF
--- a/docs/plugin_developer_guide.md
+++ b/docs/plugin_developer_guide.md
@@ -74,7 +74,7 @@ IBM Cloud CLI SDK provides a set of APIs to register and manage plug-ins. It als
 
     **Understanding the fields in this `plugin.PluginMetadata` struct:**
     - _Name_: The name of plug-in. It will be displayed when using `ibmcloud plugin list` command or can be used to uninstall the plug-in through `ibmcloud plugin uninstall` command.
-      - It is **strongly** encouraged to use a name that best describes the service the plug-in is provided.
+      - It is **strongly** encouraged to use a name that best describes the service the plug-in provides.
     - _Aliases_: A list of short names of the plug-in that can be used as a stand-in for installing, updating, uninstalling and using the plug-in.
       - It is strongly recommended that you have at least one alias to improve the usability of the plug-in.
     - _Version_: The version of plug-in.

--- a/docs/plugin_developer_guide.md
+++ b/docs/plugin_developer_guide.md
@@ -74,9 +74,9 @@ IBM Cloud CLI SDK provides a set of APIs to register and manage plug-ins. It als
 
     **Understanding the fields in this `plugin.PluginMetadata` struct:**
     - _Name_: The name of plug-in. It will be displayed when using `ibmcloud plugin list` command or can be used to uninstall the plug-in through `ibmcloud plugin uninstall` command.
-      - It **strongly** encouraged to use a name that best describes the service the plugin is provided.
-    - _Aliases_: A list of short names of the plugin's name that can be used as a stand-in for installing or uninstall the plugin.
-      - It is strongly recommended that you have at least one alias to better usability of the plugin.
+      - It is **strongly** encouraged to use a name that best describes the service the plug-in is provided.
+    - _Aliases_: A list of short names of the plug-in that can be used as a stand-in for installing, updating, uninstalling and using the plug-in.
+      - It is strongly recommended that you have at least one alias to improve the usability of the plug-in.
     - _Version_: The version of plug-in.
     - _MinCliVersion_: The minimal version of IBM Cloud CLI required by the plug-in.
     - _PrivateEndpointSupported_: Indicates if the plug-in is designed to also be used over the private network.

--- a/docs/plugin_developer_guide.md
+++ b/docs/plugin_developer_guide.md
@@ -74,6 +74,9 @@ IBM Cloud CLI SDK provides a set of APIs to register and manage plug-ins. It als
 
     **Understanding the fields in this `plugin.PluginMetadata` struct:**
     - _Name_: The name of plug-in. It will be displayed when using `ibmcloud plugin list` command or can be used to uninstall the plug-in through `ibmcloud plugin uninstall` command.
+      - It **strongly** encouraged to use a name that best describes the service the plugin is provided.
+    - _Aliases_: A list of short names of the plugin's name that can be used as a stand-in for installing or uninstall the plugin.
+      - It is strongly recommended that you have at least one alias to better usability of the plugin.
     - _Version_: The version of plug-in.
     - _MinCliVersion_: The minimal version of IBM Cloud CLI required by the plug-in.
     - _PrivateEndpointSupported_: Indicates if the plug-in is designed to also be used over the private network.


### PR DESCRIPTION
# Context

The purpose of this PR is to provide clearly expectations to use a proper plugin name and alias when designing a plugin. It is important that plugin's names clearly describe what service the plugin is providing as well as short alias name for uninstall and installing the plugin.
