### PR TITLE
chore: Excluded .nancy-ignore in secrets.baseline file

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,6 +1,6 @@
 {
   "exclude": {
-    "files": "^.secrets.baseline$|go.sum",
+    "files": "^.secrets.baseline$|go.sum|.nancy-ignore",
     "lines": null
   },
   "generated_at": "2022-07-08T20:25:00Z",


### PR DESCRIPTION
# Context

The purpose of this PR is to exclude the .nancy-ignore file from the security scan
