### PR TITLE
Win unit test

### DIFF
--- a/bluemix/configuration/config_helpers/helpers_test.go
+++ b/bluemix/configuration/config_helpers/helpers_test.go
@@ -30,7 +30,11 @@ func captureAndPrepareEnv(a *assert.Assertions) ([]string, string) {
 	os.Unsetenv("IBMCLOUD_HOME")
 	os.Unsetenv("BLUEMIX_HOME")
 	os.Setenv("HOME", userHome)
-
+	// UserHomeDir() uses HOMEDRIVE + HOMEPATH for windows
+	if os.Getenv("OS") == "Windows_NT" {
+		// ioutil.TempDir has the drive letter in the path, so we need to remove it when we set HOMEDRIVE
+		os.Setenv("HOMEPATH", strings.Replace(userHome, os.Getenv("HOMEDRIVE"), "", -1))
+	}
 	a.NoError(os.RemoveAll(userHome))
 
 	return env, userHome

--- a/bluemix/configuration/config_helpers/helpers_test.go
+++ b/bluemix/configuration/config_helpers/helpers_test.go
@@ -10,16 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// import (
-// 	"io/ioutil"
-// 	"os"
-// 	"path/filepath"
-// 	"testing"
-
-// 	"github.com/stretchr/testify/assert"
-// 	"github.ibm.com/bluemix-cli-release/build/src/github.ibm.com/Bluemix/bluemix-cli-common/file_helpers"
-// )
-
 func captureAndPrepareEnv(a *assert.Assertions) ([]string, string) {
 	env := os.Environ()
 

--- a/bluemix/env_test.go
+++ b/bluemix/env_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestGet(t *testing.T) {
-	assert.Empty(t, EnvTrace.Get())
-
 	os.Setenv("IBMCLOUD_TRACE", "true")
 	assert.Equal(t, "true", EnvTrace.Get())
 


### PR DESCRIPTION
## Before

```bash
allmi@SPF-WIN10 MINGW64 ~/go/src/github.com/IBM-Cloud/ibm-cloud-cli-sdk (dev)
$ go test github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/configuration/config_helpers
--- FAIL: TestConfigDir_NothingSet_NothingExists (0.00s)
    helpers_test.go:56:
                Error Trace:    helpers_test.go:56
                Error:          Not equal:
                                expected: "C:\\Users\\allmi\\AppData\\Local\\Temp\\config_dir_test3369573905\\.bluemix"
                                actual  : "C:\\Users\\allmi\\.bluemix"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -C:\Users\allmi\AppData\Local\Temp\config_dir_test3369573905\.bluemix
                                +C:\Users\allmi\.bluemix
                Test:           TestConfigDir_NothingSet_NothingExists
--- FAIL: TestConfigDir_NothingSet_IBMCloudExists (0.00s)
    helpers_test.go:70:
                Error Trace:    helpers_test.go:70
                Error:          Not equal:
                                expected: "C:\\Users\\allmi\\AppData\\Local\\Temp\\config_dir_test3161688745\\.ibmcloud"
                                actual  : "C:\\Users\\allmi\\.bluemix"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -C:\Users\allmi\AppData\Local\Temp\config_dir_test3161688745\.ibmcloud
                                +C:\Users\allmi\.bluemix
                Test:           TestConfigDir_NothingSet_IBMCloudExists
FAIL
FAIL    github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/configuration/config_helpers     0.038s
FAIL

```


## After


```bash
allmi@SPF-WIN10 MINGW64 ~/go/src/github.com/IBM-Cloud/ibm-cloud-cli-sdk (winUnitTest)
$ go test $(go list ./... | grep -v "plugin_examples" | grep -v "vendor")
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix  0.022s
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/authentication   (cached)
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/authentication/iam       (cached)
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/authentication/uaa       [no test files]
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/authentication/vpc       (cached)
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/configuration    [no test files]
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/configuration/config_helpers     0.037s
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/configuration/core_config        0.070s
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/crn      (cached)
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/endpoints        (cached)
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/http     (cached)
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/models   [no test files]
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/terminal (cached)
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/trace    (cached)
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/common/downloader        (cached)
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/common/file_helpers      [no test files]
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/common/rest      (cached)
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/common/rest/helpers      (cached)
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/common/types     [no test files]
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/i18n     [no test files]
ok      github.com/IBM-Cloud/ibm-cloud-cli-sdk/plugin   (cached)
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/plugin/pluginfakes       [no test files]
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/resources        [no test files]
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/testhelpers      [no test files]
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/testhelpers/configuration        [no test files]
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/testhelpers/matchers     [no test files]
?       github.com/IBM-Cloud/ibm-cloud-cli-sdk/testhelpers/terminal     [no test files]
```