### PR TITLE
Fix: Excluding Windows `GOOS` from `flock` file mutex logic

### DIFF
--- a/bluemix/configuration/persistor.go
+++ b/bluemix/configuration/persistor.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/IBM-Cloud/ibm-cloud-cli-sdk/common/file_helpers"
@@ -31,6 +33,7 @@ type DiskPersistor struct {
 	filePath      string
 	fileLock      *flock.Flock
 	parentContext context.Context
+	runtimeGOOS   string
 }
 
 func NewDiskPersistor(path string) DiskPersistor {
@@ -38,11 +41,21 @@ func NewDiskPersistor(path string) DiskPersistor {
 		filePath:      path,
 		fileLock:      flock.New(path),
 		parentContext: context.Background(),
+		runtimeGOOS:   runtime.GOOS,
 	}
 }
 
 func (dp DiskPersistor) Exists() bool {
 	return file_helpers.FileExists(dp.filePath)
+}
+
+func (dp *DiskPersistor) windowsLockedRead(data DataInterface) error {
+	// TO DO: exclusive file-locking for the reading NOT yet implemented
+	return dp.read(data)
+}
+
+func isBlockingLockError(err error) bool {
+	return err != nil && !strings.Contains(err.Error(), "no such file or directory")
 }
 
 func (dp *DiskPersistor) lockedRead(data DataInterface) error {
@@ -52,7 +65,7 @@ func (dp *DiskPersistor) lockedRead(data DataInterface) error {
 	_, lockErr := dp.fileLock.TryLockContext(lockCtx, 100*time.Millisecond) /* provide a file lock just while dp.read is called, because it calls an unmarshaling function
 	The boolean (first return value) can be wild-carded because lockErr must be non-nil when the lock-acquiring fails (whereby the boolean will be false) */
 	defer dp.fileLock.Unlock()
-	if lockErr != nil {
+	if isBlockingLockError(lockErr) {
 		return lockErr
 	}
 	readErr := dp.read(data)
@@ -62,16 +75,39 @@ func (dp *DiskPersistor) lockedRead(data DataInterface) error {
 	return nil
 }
 
+func (dp DiskPersistor) readWithFileLock(data DataInterface) error {
+	switch dp.runtimeGOOS {
+	case "windows":
+		return dp.windowsLockedRead(data)
+	default:
+		return dp.lockedRead(data)
+	}
+}
+
+func (dp DiskPersistor) writeWithFileLock(data DataInterface) error {
+	switch dp.runtimeGOOS {
+	case "windows":
+		return dp.windowsLockedWrite(data)
+	default:
+		return dp.lockedWrite(data)
+	}
+}
+
 func (dp DiskPersistor) Load(data DataInterface) error {
-	err := dp.lockedRead(data)
+	err := dp.readWithFileLock(data)
 	if os.IsPermission(err) {
 		return err
 	}
 
 	if err != nil { /* would happen if there was nothing to read (EOF) */
-		err = dp.lockedWrite(data)
+		err = dp.writeWithFileLock(data)
 	}
 	return err
+}
+
+func (dp *DiskPersistor) windowsLockedWrite(data DataInterface) error {
+	// TO DO: exclusive file-locking for the writing NOT yet implemented
+	return dp.write(data)
 }
 
 func (dp DiskPersistor) lockedWrite(data DataInterface) error {
@@ -81,7 +117,7 @@ func (dp DiskPersistor) lockedWrite(data DataInterface) error {
 	_, lockErr := dp.fileLock.TryLockContext(lockCtx, 100*time.Millisecond) /* provide a file lock just while dp.read is called, because it calls an unmarshaling function
 	The boolean (first return value) can be wild-carded because lockErr must be non-nil when the lock-acquiring fails (whereby the boolean will be false) */
 	defer dp.fileLock.Unlock()
-	if lockErr != nil {
+	if isBlockingLockError(lockErr) {
 		return lockErr
 	}
 	writeErr := dp.write(data)
@@ -92,7 +128,7 @@ func (dp DiskPersistor) lockedWrite(data DataInterface) error {
 }
 
 func (dp DiskPersistor) Save(data DataInterface) error {
-	return dp.lockedWrite(data)
+	return dp.writeWithFileLock(data)
 }
 
 func (dp DiskPersistor) read(data DataInterface) error {

--- a/bluemix/version.go
+++ b/bluemix/version.go
@@ -3,7 +3,7 @@ package bluemix
 import "fmt"
 
 // Version is the SDK version
-var Version = VersionType{Major: 1, Minor: 0, Build: 1}
+var Version = VersionType{Major: 1, Minor: 0, Build: 2}
 
 // VersionType describe version info
 type VersionType struct {


### PR DESCRIPTION
Promotion of changes on `dev`