### PR TITLE
fix: Adding a "Connection: Close" header in HTTP requests of our Go client

### DIFF
--- a/common/rest/client.go
+++ b/common/rest/client.go
@@ -63,6 +63,7 @@ func (c *Client) DoWithContext(ctx context.Context, r *Request, respV interface{
 		client = http.DefaultClient
 	}
 
+	req.Close = true
 	resp, err := client.Do(req)
 	if err != nil {
 		return resp, err


### PR DESCRIPTION
As title!