### PR TITLE
feat: added validation method for pagination cache url

### DIFF
--- a/bluemix/configuration/config_helpers/helpers.go
+++ b/bluemix/configuration/config_helpers/helpers.go
@@ -2,6 +2,8 @@
 package config_helpers
 
 import (
+	"encoding/base64"
+	gourl "net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -90,4 +92,46 @@ func UserHomeDir() string {
 	}
 
 	return os.Getenv("HOME")
+}
+
+// IsValidPaginationNextURL will return true if the provided nextURL has the expected queries provided
+func IsValidPaginationNextURL(nextURL string, cursorQueryParamName string, expectedQueries gourl.Values) bool {
+	parsedURL, parseErr := gourl.Parse(nextURL)
+	// NOTE: ignore handling error(s) since if there error(s)
+	// we can assume the url is invalid
+	if parseErr != nil {
+		return false
+	}
+
+	// retrive encoded cursor
+	// eg. /api?cursor=<encode_string>
+	queries := parsedURL.Query()
+	encodedQuery := queries.Get(cursorQueryParamName)
+	if encodedQuery == "" {
+		return false
+
+	}
+	// decode string and parse encoded queries
+	decodedQuery, decodedErr := base64.RawURLEncoding.DecodeString(encodedQuery)
+	if decodedErr != nil {
+		return false
+	}
+	queries, parsedErr := gourl.ParseQuery(string(decodedQuery))
+	if parsedErr != nil {
+		return false
+	}
+
+	// compare expected queries that should match
+	// NOTE: assume queries are single value queries.
+	// if multi-value queries will check the first query
+	for expectedQuery := range expectedQueries {
+		paginationQueryValue := queries.Get(expectedQuery)
+		expectedQueryValue := expectedQueries.Get(expectedQuery)
+		if paginationQueryValue != expectedQueryValue {
+			return false
+		}
+
+	}
+
+	return true
 }

--- a/common/rest/request_test.go
+++ b/common/rest/request_test.go
@@ -137,11 +137,13 @@ func TestCachedPaginationNextURL(t *testing.T) {
 		name            string
 		paginationURLs  []models.PaginationURL
 		offset          int
+		limit           int
 		expectedNextURL string
 	}{
 		{
 			name:   "return cached next URL",
 			offset: 200,
+			limit:  100,
 			paginationURLs: []models.PaginationURL{
 				{
 					NextURL:   "/v2/example.com/stuff?limit=100",
@@ -153,6 +155,7 @@ func TestCachedPaginationNextURL(t *testing.T) {
 		{
 			name:   "return empty string if cache URL cannot be determined",
 			offset: 40,
+			limit:  100,
 			paginationURLs: []models.PaginationURL{
 				{
 					NextURL:   "/v2/example.com/stuff?limit=100",
@@ -164,7 +167,20 @@ func TestCachedPaginationNextURL(t *testing.T) {
 		{
 			name:            "return empty string if no cache available",
 			offset:          40,
+			limit:           100,
 			paginationURLs:  []models.PaginationURL{},
+			expectedNextURL: "",
+		},
+		{
+			name:   "return empty string if limit in url is different than provided limit",
+			offset: 200,
+			limit:  200,
+			paginationURLs: []models.PaginationURL{
+				{
+					NextURL:   "/v2/example.com?stuff?limit=100",
+					LastIndex: 100,
+				},
+			},
 			expectedNextURL: "",
 		},
 	}

--- a/common/rest/request_test.go
+++ b/common/rest/request_test.go
@@ -137,13 +137,11 @@ func TestCachedPaginationNextURL(t *testing.T) {
 		name            string
 		paginationURLs  []models.PaginationURL
 		offset          int
-		limit           int
 		expectedNextURL string
 	}{
 		{
 			name:   "return cached next URL",
 			offset: 200,
-			limit:  100,
 			paginationURLs: []models.PaginationURL{
 				{
 					NextURL:   "/v2/example.com/stuff?limit=100",
@@ -155,7 +153,6 @@ func TestCachedPaginationNextURL(t *testing.T) {
 		{
 			name:   "return empty string if cache URL cannot be determined",
 			offset: 40,
-			limit:  100,
 			paginationURLs: []models.PaginationURL{
 				{
 					NextURL:   "/v2/example.com/stuff?limit=100",
@@ -167,20 +164,7 @@ func TestCachedPaginationNextURL(t *testing.T) {
 		{
 			name:            "return empty string if no cache available",
 			offset:          40,
-			limit:           100,
 			paginationURLs:  []models.PaginationURL{},
-			expectedNextURL: "",
-		},
-		{
-			name:   "return empty string if limit in url is different than provided limit",
-			offset: 200,
-			limit:  200,
-			paginationURLs: []models.PaginationURL{
-				{
-					NextURL:   "/v2/example.com?stuff?limit=100",
-					LastIndex: 100,
-				},
-			},
 			expectedNextURL: "",
 		},
 	}


### PR DESCRIPTION
# Context

The purpose of this PR is to add a validation method to check if the next url contains the expected queries used during pagination. For instance, if the user is paginating with the `active` query parameter any cached url that is missing the `active` query parameter is invalid


# Steps to Test

## Run the unit tests
1. Run the command: `go test -v -count=1 ./...`
2. Verify that all tests pass

