### PR TITLE
feat: add crn check & feat: add assumed TP readers/modifiers

### DIFF
--- a/bluemix/configuration/core_config/bx_config.go
+++ b/bluemix/configuration/core_config/bx_config.go
@@ -24,36 +24,41 @@ func (r raw) Unmarshal(bytes []byte) error {
 }
 
 type BXConfigData struct {
-	APIEndpoint                 string
-	IsPrivate                   bool
-	IsAccessFromVPC             bool
-	ConsoleEndpoint             string
-	ConsolePrivateEndpoint      string
-	ConsolePrivateVPCEndpoint   string
-	CloudType                   string
-	CloudName                   string
-	CRIType                     string
-	Region                      string
-	RegionID                    string
-	IAMEndpoint                 string
-	IAMPrivateEndpoint          string
-	IAMPrivateVPCEndpoint       string
-	IAMToken                    string
-	IAMRefreshToken             string
-	IsLoggedInAsCRI             bool
-	Account                     models.Account
-	Profile                     models.Profile
-	ResourceGroup               models.ResourceGroup
-	LoginAt                     time.Time
-	PluginRepos                 []models.PluginRepo
-	SSLDisabled                 bool
-	Locale                      string
-	MessageOfTheDayTime         int64
-	LastSessionUpdateTime       int64
-	Trace                       string
-	ColorEnabled                string
-	HTTPTimeout                 int
-	TypeOfSSO                   string
+	APIEndpoint               string
+	IsPrivate                 bool
+	IsAccessFromVPC           bool
+	ConsoleEndpoint           string
+	ConsolePrivateEndpoint    string
+	ConsolePrivateVPCEndpoint string
+	CloudType                 string
+	CloudName                 string
+	CRIType                   string
+	Region                    string
+	RegionID                  string
+	IAMEndpoint               string
+	IAMPrivateEndpoint        string
+	IAMPrivateVPCEndpoint     string
+	IAMToken                  string
+	IAMRefreshToken           string
+	IsLoggedInAsCRI           bool
+	Account                   models.Account
+	Profile                   models.Profile
+	ResourceGroup             models.ResourceGroup
+	LoginAt                   time.Time
+	PluginRepos               []models.PluginRepo
+	SSLDisabled               bool
+	Locale                    string
+	MessageOfTheDayTime       int64
+	LastSessionUpdateTime     int64
+	Trace                     string
+	ColorEnabled              string
+	HTTPTimeout               int
+	TypeOfSSO                 string
+	FallbackIAMTokens         struct {
+		IAMToken        string
+		IAMRefreshToken string
+	}
+	AssumedTrustedProfileId     string
 	CLIInfoEndpoint             string // overwrite the cli info endpoint
 	CheckCLIVersionDisabled     bool
 	UsageStatsDisabled          bool // deprecated: use UsageStatsEnabled
@@ -417,6 +422,27 @@ func (c *bxConfig) TypeOfSSO() (style string) {
 	return
 }
 
+func (c *bxConfig) FallbackIAMToken() (t string) {
+	c.read(func() {
+		t = c.data.FallbackIAMTokens.IAMToken
+	})
+	return
+}
+
+func (c *bxConfig) FallbackIAMRefreshToken() (t string) {
+	c.read(func() {
+		t = c.data.FallbackIAMTokens.IAMRefreshToken
+	})
+	return
+}
+
+func (c *bxConfig) AssumedTrustedProfileId() (id string) {
+	c.read(func() {
+		id = c.data.AssumedTrustedProfileId
+	})
+	return
+}
+
 func (c *bxConfig) HTTPTimeout() (timeout int) {
 	c.read(func() {
 		timeout = c.data.HTTPTimeout
@@ -632,6 +658,19 @@ func (c *bxConfig) SetHTTPTimeout(timeout int) {
 func (c *bxConfig) SetTypeOfSSO(style string) {
 	c.write(func() {
 		c.data.TypeOfSSO = style
+	})
+}
+
+func (c *bxConfig) SetFallbackIAMTokens(token, refreshToken string) {
+	c.write(func() {
+		c.data.FallbackIAMTokens.IAMToken = token
+		c.data.FallbackIAMTokens.IAMRefreshToken = refreshToken
+	})
+}
+
+func (c *bxConfig) SetAssumedTrustedProfileId(id string) {
+	c.write(func() {
+		c.data.AssumedTrustedProfileId = id
 	})
 }
 

--- a/bluemix/configuration/core_config/repository.go
+++ b/bluemix/configuration/core_config/repository.go
@@ -52,6 +52,9 @@ type Repository interface {
 	PluginRepo(string) (models.PluginRepo, bool)
 	IsSSLDisabled() bool
 	TypeOfSSO() string
+	AssumedTrustedProfileId() string
+	FallbackIAMToken() string
+	FallbackIAMRefreshToken() string
 	HTTPTimeout() int
 	CLIInfoEndpoint() string
 	CheckCLIVersionDisabled() bool
@@ -90,6 +93,8 @@ type Repository interface {
 	SetRegion(models.Region)
 	SetIAMToken(string)
 	SetIAMRefreshToken(string)
+	SetFallbackIAMTokens(string, string)
+	SetAssumedTrustedProfileId(string)
 	ClearSession()
 	SetAccount(models.Account)
 	SetProfile(models.Profile)

--- a/bluemix/crn/crn.go
+++ b/bluemix/crn/crn.go
@@ -114,7 +114,7 @@ func Parse(s string) (CRN, error) {
 }
 
 func (c CRN) String() string {
-	return strings.Join([]string{
+	joinedValue := strings.Join([]string{
 		c.Scheme,
 		c.Version,
 		c.CName,
@@ -126,6 +126,10 @@ func (c CRN) String() string {
 		c.ResourceType,
 		c.Resource,
 	}, crnSeparator)
+	if joinedValue == ":::::::::" {
+		return ""
+	}
+	return joinedValue // do not return a CRN that is just a series of separators, with no string content
 }
 
 func (c CRN) ScopeSegment() string {

--- a/bluemix/crn/crn.go
+++ b/bluemix/crn/crn.go
@@ -127,9 +127,9 @@ func (c CRN) String() string {
 		c.Resource,
 	}, crnSeparator)
 	if joinedValue == ":::::::::" {
-		return ""
+		return "" // do not return a CRN that is just a series of separators, with no string content
 	}
-	return joinedValue // do not return a CRN that is just a series of separators, with no string content
+	return joinedValue
 }
 
 func (c CRN) ScopeSegment() string {


### PR DESCRIPTION
The files changed here add a check to return an empty string (which will result in omission with the `omitempty` JSON-formatting tag), instead of `:::::::::`, if all of the 10 colon-delimited components of the CRN are empty.

Left behind last time but also necessary for the next merge/deploy (and therefore included here) are changes to the module for reading from and writing to the core configuration file, which we need in order to support assuming a TP on the CLI.