### PR TITLE
chore: change the minor version number

### DIFF
--- a/bluemix/version.go
+++ b/bluemix/version.go
@@ -3,7 +3,7 @@ package bluemix
 import "fmt"
 
 // Version is the SDK version
-var Version = VersionType{Major: 1, Minor: 4, Build: 0}
+var Version = VersionType{Major: 1, Minor: 5, Build: 0}
 
 // VersionType describe version info
 type VersionType struct {


### PR DESCRIPTION
We're releasing a new version of the CLI SDK to be up-to-date with the latest changes on the IBM Cloud CLI.