### PR TITLE
feat: added AlphaCommandsEnabled configuration

### DIFF
--- a/bluemix/configuration/core_config/bx_config.go
+++ b/bluemix/configuration/core_config/bx_config.go
@@ -52,6 +52,7 @@ type BXConfigData struct {
 	LastSessionUpdateTime     int64
 	Trace                     string
 	ColorEnabled              string
+	AlphaCommandsEnabled      string
 	HTTPTimeout               int
 	TypeOfSSO                 string
 	FallbackIAMTokens         struct {
@@ -415,6 +416,13 @@ func (c *bxConfig) ColorEnabled() (enabled string) {
 	return
 }
 
+func (c *bxConfig) AlphaCommandsEnabled() (enabled string) {
+	c.read(func() {
+		enabled = c.data.AlphaCommandsEnabled
+	})
+	return
+}
+
 func (c *bxConfig) TypeOfSSO() (style string) {
 	c.read(func() {
 		style = c.data.TypeOfSSO
@@ -720,6 +728,12 @@ func (c *bxConfig) SetUsageStatsEnabled(enabled bool) {
 func (c *bxConfig) SetColorEnabled(enabled string) {
 	c.write(func() {
 		c.data.ColorEnabled = enabled
+	})
+}
+
+func (c *bxConfig) SetAlphaCommandsEnabled(enabled string) {
+	c.write(func() {
+		c.data.AlphaCommandsEnabled = enabled
 	})
 }
 

--- a/bluemix/configuration/core_config/repository.go
+++ b/bluemix/configuration/core_config/repository.go
@@ -52,6 +52,7 @@ type Repository interface {
 	PluginRepo(string) (models.PluginRepo, bool)
 	IsSSLDisabled() bool
 	TypeOfSSO() string
+	AlphaCommandsEnabled() string
 	AssumedTrustedProfileId() string
 	FallbackIAMToken() string
 	FallbackIAMRefreshToken() string
@@ -118,6 +119,7 @@ type Repository interface {
 	SetLocale(string)
 	SetTrace(string)
 	SetColorEnabled(string)
+	SetAlphaCommandsEnabled(string)
 
 	CheckMessageOfTheDay() bool
 	SetMessageOfTheDayTime()


### PR DESCRIPTION
# Context

The purpose of this PR is to add a new configuration called `AlphaCommandsEnabled` which will handle sorting commands alphabetically uncategorized in the help usage text 
