### PR TITLE
fix: restore secrets baseline file

### DIFF
--- a/.secrets-baseline
+++ b/.secrets-baseline
@@ -1,0 +1,374 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$|go.sum|.nancy-ignore",
+    "lines": null
+  },
+  "generated_at": "2023-10-16T15:47:30Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "bluemix/authentication/iam/iam.go": [
+      {
+        "hashed_secret": "1f7e33de15e22de9d2eaf502df284ed25ca40018",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c2df5d3d760ff42f33fb38e2534d4c1b7ddde3ab",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c287d1da815abde11f19d14ab6f9dba01f57698e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "41aaaaa69550b140807e70dcc170a497dbeadf0d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ca51a3e5092ede254e7121c4fc9fb07a0a55f2a0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d327b16674fb457f595a2bc5cdbd98f8143632be",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3c81615afb40d1889fc2e1fff551a8b59b4e80ce",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 37,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3438d9111af8058916e075b463bd7a6583cbf012",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 265,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "53213c46677ac6f5576c44a4cbbdbe186d67cb00",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 267,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "bluemix/authentication/iam/iam_test.go": [
+      {
+        "hashed_secret": "c8f0df25bade89c1873f5f01b85bcfb921443ac6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 21,
+        "type": "JSON Web Token",
+        "verified_result": null
+      }
+    ],
+    "bluemix/authentication/uaa/uaa.go": [
+      {
+        "hashed_secret": "3438d9111af8058916e075b463bd7a6583cbf012",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 116,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "bluemix/authentication/vpc/vpc_test.go": [
+      {
+        "hashed_secret": "baa11828b713288370b2ae5b7dd012ab8e875ca7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c8f0df25bade89c1873f5f01b85bcfb921443ac6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 20,
+        "type": "JSON Web Token",
+        "verified_result": null
+      }
+    ],
+    "bluemix/configuration/core_config/bx_config_test.go": [
+      {
+        "hashed_secret": "90919f1360ad1f9525de7a64061c105d061df1c8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 378,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "40e89785a3d6a88c5ef431f64ec054b1d39e186e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 394,
+        "type": "JSON Web Token",
+        "verified_result": null
+      }
+    ],
+    "bluemix/configuration/core_config/cf_config.go": [
+      {
+        "hashed_secret": "e85f6eac7402c010fcea6b6d024a1875ac213f99",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 240,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "bluemix/configuration/core_config/iam_token_test.go": [
+      {
+        "hashed_secret": "8d8e2cec529a6f642c25b4473b2adc8cde563c36",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de89e230a57dd89a612cc8439c00d0001ffa6389",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 21,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6a4b65a72c0da02a03007867d9838f4a256a384b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 27,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "42be9b0e85dc9f0fcb42c69058b133fd23dfde2b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 33,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "73f596843cdc77ecc6a0a4cdc5b5d89071ad1b79",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 37,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c017c618a0ef5209f2cbbb367a7c68eb0404e043",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 47,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6160045cbf6bfe6c1669311f5720fd73cbe56243",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 57,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "63a47776714d85556701c61dd731a302ed132385",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 76,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "bluemix/configuration/core_config/uaa_token_test.go": [
+      {
+        "hashed_secret": "c017c618a0ef5209f2cbbb367a7c68eb0404e043",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3c1dbf49c59ee96e6a9ac90bea40471c0cb8b4f1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 32,
+        "type": "JSON Web Token",
+        "verified_result": null
+      }
+    ],
+    "bluemix/env.go": [
+      {
+        "hashed_secret": "33e5e588d24c979db687c950cf004784e95ddb1b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "bluemix/trace/trace_test.go": [
+      {
+        "hashed_secret": "41dfa2b9f3f8576ba98aa00f84f57dc5559fd07b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cb433c7f7663caf3588ff383d5f92c8bb689f2e7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 38,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2308d0fb5ab83a7e92e8000f5f094342d3f87bd0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8263549977af79975131821bcc1dad766a967816",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/interface_summary.md": [
+      {
+        "hashed_secret": "616e17a3f6182ce45befae8060d30bcb969a2897",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 261,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "docs/plugin_developer_guide.md": [
+      {
+        "hashed_secret": "616e17a3f6182ce45befae8060d30bcb969a2897",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 727,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.61.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
The secrets baseline file should not have been removed with the Travis config. Restoring this file.