### PR TITLE
chore: hardcoded terminal width to a large number

### DIFF
--- a/bluemix/terminal/table.go
+++ b/bluemix/terminal/table.go
@@ -146,7 +146,7 @@ func (t *PrintableTable) createColumnConfigs() []table.ColumnConfig {
 	colCount := len(t.rows[0])
 	var (
 		widestColIndicies []int
-		terminalWidth     = terminalWidth()
+		terminalWidth     = 1000
 		// total amount padding space that a row will take up
 		totalPaddingSpace = (colCount - 1) * minSpace
 		remainingSpace    = max(0, terminalWidth-totalPaddingSpace)

--- a/bluemix/terminal/table_test.go
+++ b/bluemix/terminal/table_test.go
@@ -95,6 +95,7 @@ func TestMoreColThanTerminalWidth(t *testing.T) {
 }
 
 func TestWideHeaderNames(t *testing.T) {
+	t.Skip("Skip until terminal width issue is fixed")
 	buf := bytes.Buffer{}
 	testTable := NewTable(&buf, []string{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt u", "NAME"})
 	testTable.Add("col1", "col2")
@@ -114,6 +115,7 @@ func TestWidestColumn(t *testing.T) {
 }
 
 func TestMultiWideColumns(t *testing.T) {
+	t.Skip("Skip until terminal width issue is fixed")
 	buf := bytes.Buffer{}
 	id := "ABCDEFG-9b8babbd-f2ed-4371-b817-a839e4130332"
 	desc := "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut"


### PR DESCRIPTION
# Context


There is an issue with table rows wrapping causing problems for customers. It is possible it is due to how `term.GetSize` is determining the width size. Until the issue is resolved we will set the terminal width to a large amount to prevent wrapping
