### PR TITLE
chore: bump golang to 1.22.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM-Cloud/ibm-cloud-cli-sdk
 
-go 1.22.3
+go 1.22.11
 
 require (
 	github.com/fatih/color v1.7.1-0.20180516100307-2d684516a886


### PR DESCRIPTION
This PR updates the Golang version as was done in `master` previously.