### PR TITLE
chore: bump version to 1.7.1

### DIFF
--- a/bluemix/version.go
+++ b/bluemix/version.go
@@ -3,7 +3,7 @@ package bluemix
 import "fmt"
 
 // Version is the SDK version
-var Version = VersionType{Major: 1, Minor: 7, Build: 0}
+var Version = VersionType{Major: 1, Minor: 7, Build: 1}
 
 // VersionType describe version info
 type VersionType struct {


### PR DESCRIPTION
New release that updates vulnerable dependency versions