### PR TITLE
fix: included all flags in metadata

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -111,6 +111,12 @@ func (c Command) NameAndAliases() []string {
 // Method is used when defining the Flags in command metadata. @see Plugin#GetMetadata() for use case
 func ConvertCobraFlagsToPluginFlags(cmd *cobra.Command) []Flag {
 	var flags []Flag
+	// NOTE: there is a strange behavior in Cobra where you need to call
+	// either `InheritedFlags` or `LocalFlags` in order to include global
+	// flags when calling `VisitAll`
+	// see https://github.com/spf13/cobra/issues/412
+	cmd.InheritedFlags()
+
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		var name string
 		if f.Shorthand != "" {

--- a/testhelpers/terminal/test_ui.go
+++ b/testhelpers/terminal/test_ui.go
@@ -221,6 +221,10 @@ func (ui *FakeUI) Writer() io.Writer {
 	return &ui.stdOut
 }
 
+func (ui *FakeUI) ErrWriter() io.Writer {
+	return &ui.stdErr
+}
+
 func (ui *FakeUI) SetQuiet(quiet bool) {
 	ui.quiet = quiet
 }


### PR DESCRIPTION
# Context


The purpose of this PR is resolve the issue where only the local flags were included in a plug-in's metadata. There is a strange bug in Cobra where you need to call either `InheriteFlags()` or `LocalFlags()` in order to include global flags before visiting all the flags (see https://github.com/spf13/cobra/issues/412)



