### PR TITLE
chore: added mock methods for both SetErrWriter and SetWriter

### DIFF
--- a/testhelpers/terminal/test_ui.go
+++ b/testhelpers/terminal/test_ui.go
@@ -228,11 +228,17 @@ func (ui *FakeUI) ErrWriter() io.Writer {
 	return &ui.stdErr
 }
 
-// NOTE: Adding method to satisfy go
-func (ui *FakeUI) SetErrWriter(buf io.Writer) {}
+// NOTE: SetErrWriter is added here since the method is part of the UI type Interface interface
+// the method is not needed for testing
+func (ui *FakeUI) SetErrWriter(buf io.Writer) {
+	panic("unimplemented")
+}
 
-// NOTE: not needed since we write directly using the bytes.Buffer
-func (ui *FakeUI) SetWriter(buf io.Writer) {}
+// NOTE: SetErrWriter is added here since the method is part of the UI type Interface interface
+// the method is not needed for testing
+func (ui *FakeUI) SetWriter(buf io.Writer) {
+	panic("unimplemented")
+}
 
 func (ui *FakeUI) SetQuiet(quiet bool) {
 	ui.quiet = quiet


### PR DESCRIPTION
# Context

The purpose of this PR is to prevent `go vet` from throwing the missing implementation error for `SetErrWriter` and `SetWriter` in the `testhelpers` package. 

# Callout
- I have set the methods as unimplemented because there is no way to override a bytes.Buffer using an io.Writer in Golang since io.Writer is a type of bytes.Buffer. To workaround this issue, the user should not set the buffers for either `stdout` or `stderr` directly but use a testing framework to assert the result from either buffer. I am open to other suggestions


