### PR TITLE
feat: added method to check if CLI is in MCP mode

### DIFF
--- a/bluemix/env.go
+++ b/bluemix/env.go
@@ -33,6 +33,7 @@ var (
 	// for internal use
 	EnvCLIName         = newEnv("IBMCLOUD_CLI", "BLUEMIX_CLI")
 	EnvPluginNamespace = newEnv("IBMCLOUD_PLUGIN_NAMESPACE", "BLUEMIX_PLUGIN_NAMESPACE")
+	EnvMCP             = newEnv("IBMCLOUD_MCP_ENABLED")
 )
 
 // Env is an environment variable supported by IBM Cloud CLI for specific purpose

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -298,4 +298,7 @@ type PluginContext interface {
 
 	// CLIName returns binary name of the Bluemix CLI that is invoking the plugin
 	CLIName() string
+
+	// MCPEnabled returns true if the CLI is functioning as an MCP server
+	MCPEnabled() bool
 }

--- a/plugin/plugin_context.go
+++ b/plugin/plugin_context.go
@@ -116,6 +116,10 @@ func (c *pluginContext) VersionCheckEnabled() bool {
 	return !c.CheckCLIVersionDisabled()
 }
 
+func (c *pluginContext) MCPEnabled() bool {
+	return bluemix.EnvMCP.Get() != ""
+}
+
 func envOrConfig(env bluemix.Env, config string) string {
 	if v := env.Get(); v != "" {
 		return v


### PR DESCRIPTION
# Context

The purpose of this PR is to add a new method called *MCPEnabled* in the **PluginContext** module which will allow users to determine whether or not the CLI is running as a MCP server
