### PR TITLE
chore: added check to not print correlation ID on certain reqs

### DIFF
--- a/bluemix/authentication/iam/iam.go
+++ b/bluemix/authentication/iam/iam.go
@@ -4,8 +4,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/IBM-Cloud/ibm-cloud-cli-sdk/bluemix/authentication"
@@ -50,6 +52,9 @@ const (
 	SessionInactiveErrorCode        = "BXNIM0439E"
 )
 
+// list of request paths that will not print the correlation IDs
+var RequestPathsIgnoreCorrelationID = []string{"/v1/sessions"}
+
 type MFAVendor string
 
 func (m MFAVendor) String() string {
@@ -62,6 +67,15 @@ const (
 	MFAVendorTOTP        MFAVendor = "TOTP"
 	MFAVendorPhoneFactor MFAVendor = "PHONE_FACTOR"
 )
+
+func AllowPrintCorrelationID(path string) bool {
+	for _, urlPath := range RequestPathsIgnoreCorrelationID {
+		if strings.Contains(path, urlPath) {
+			return false
+		}
+	}
+	return true
+}
 
 func PasswordTokenRequest(username, password string, opts ...authentication.TokenOption) *authentication.TokenRequest {
 	r := authentication.NewTokenRequest(GrantTypePassword)
@@ -355,6 +369,7 @@ func (c *client) GetEndpoint() (*Endpoint, error) {
 func (c *client) doRequest(r *rest.Request, respV interface{}) error {
 
 	var err error
+	var res *http.Response
 	var uuidBytes uuid.UUID
 	var correlationBytes uuid.UUID
 
@@ -366,10 +381,12 @@ func (c *client) doRequest(r *rest.Request, respV interface{}) error {
 		r.Set("X-Correlation-ID", correlationBytes.String())
 	}
 
-	_, err = c.client.Do(r, respV, nil)
+	res, err = c.client.Do(r, respV, nil)
 	switch err := err.(type) {
 	case *rest.ErrorResponse:
-		fmt.Println("Correlation-ID: " + correlationBytes.String())
+		if AllowPrintCorrelationID(res.Request.URL.Path) {
+			fmt.Println("Correlation-ID: " + correlationBytes.String())
+		}
 		var apiErr APIError
 		if jsonErr := json.Unmarshal([]byte(err.Message), &apiErr); jsonErr == nil {
 			switch apiErr.ErrorCode {

--- a/bluemix/authentication/iam/iam_test.go
+++ b/bluemix/authentication/iam/iam_test.go
@@ -311,6 +311,26 @@ func TestRefreshSession(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestAllowPrintCorrelationID(t *testing.T) {
+	testCases := []struct {
+		path                    string
+		allowPrintCorrelationID bool
+	}{
+		{
+			path:                    "/v1/sessions",
+			allowPrintCorrelationID: false,
+		},
+		{
+			path:                    "/v1/tokens",
+			allowPrintCorrelationID: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		assert.Equal(t, AllowPrintCorrelationID(testCase.path), testCase.allowPrintCorrelationID)
+	}
+}
+
 // startMockIAMServerForCRExchange will start a mock server endpoint that supports both the
 // IAM operations that we'll need to call.
 func startMockIAMServerForCRExchange(t *testing.T, call int, statusCode int, errorJson string) *httptest.Server {


### PR DESCRIPTION
# Context

The purpose of this PR is to suppress printing the **Correlation IDs** on certain requests (eg. `/v1/sesssion`)
