### PR TITLE
chore: bump version to 1.9.0

### DIFF
--- a/bluemix/version.go
+++ b/bluemix/version.go
@@ -3,7 +3,7 @@ package bluemix
 import "fmt"
 
 // Version is the SDK version
-var Version = VersionType{Major: 1, Minor: 8, Build: 1}
+var Version = VersionType{Major: 1, Minor: 9, Build: 0}
 
 // VersionType describe version info
 type VersionType struct {


### PR DESCRIPTION
Set the version to 1.9.0 in preparation for release.