### PR TITLE
Replace usages of deprecated ioutil package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The following is a set of guidelines for` contributing to IBM Cloud CLI SDK. If 
 
 #### Code Style
 
-We follow the offical [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments). Make sure you run [gofmt](https://golang.org/cmd/gofmt/) and [go vet](https://golang.org/cmd/vet/) to fix any major changes.
+We follow the official [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments). Make sure you run [gofmt](https://golang.org/cmd/gofmt/) and [go vet](https://golang.org/cmd/vet/) to fix any major changes.
 
 #### Unit Test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ The following is a set of guidelines for` contributing to IBM Cloud CLI SDK. If 
 
 ### Before You Submit PR
 
+#### Base branch
+
+This repository's default branch is master as that is from where we release. However, we develop in the **dev** branch. Make sure to create your feature branch from **dev** and also choose this as base for opening pull requests.
+
 #### Code Style
 
 We follow the official [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments). Make sure you run [gofmt](https://golang.org/cmd/gofmt/) and [go vet](https://golang.org/cmd/vet/) to fix any major changes.

--- a/bluemix/configuration/config_helpers/helpers_test.go
+++ b/bluemix/configuration/config_helpers/helpers_test.go
@@ -2,7 +2,6 @@ package config_helpers
 
 import (
 	"encoding/base64"
-	"io/ioutil"
 	gourl "net/url"
 	"os"
 	"path/filepath"
@@ -15,7 +14,7 @@ import (
 func captureAndPrepareEnv(a *assert.Assertions) ([]string, string) {
 	env := os.Environ()
 
-	userHome, err := ioutil.TempDir("", "config_dir_test")
+	userHome, err := os.MkdirTemp("", "config_dir_test")
 	a.NoError(err)
 
 	os.Unsetenv("IBMCLOUD_CONFIG_HOME")

--- a/bluemix/configuration/core_config/bx_config_test.go
+++ b/bluemix/configuration/core_config/bx_config_test.go
@@ -2,7 +2,6 @@ package core_config_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -555,7 +554,7 @@ func checkUsageStats(enabled bool, timeStampExist bool, config core_config.Repos
 }
 
 func prepareConfigForCLI(cliConfigContent string, t *testing.T) core_config.Repository {
-	ioutil.WriteFile("config.json", []byte(cliConfigContent), 0644)
+	os.WriteFile("config.json", []byte(cliConfigContent), 0644)
 	return core_config.NewCoreConfigFromPath("config.json", func(err error) {
 		t.Fatal(err.Error())
 	})

--- a/bluemix/configuration/persistor.go
+++ b/bluemix/configuration/persistor.go
@@ -2,7 +2,6 @@ package configuration
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -137,7 +136,7 @@ func (dp DiskPersistor) read(data DataInterface) error {
 		return err
 	}
 
-	bytes, err := ioutil.ReadFile(dp.filePath)
+	bytes, err := os.ReadFile(dp.filePath)
 	if err != nil {
 		return err
 	}
@@ -152,6 +151,6 @@ func (dp DiskPersistor) write(data DataInterface) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(dp.filePath, bytes, filePermissions)
+	err = os.WriteFile(dp.filePath, bytes, filePermissions)
 	return err
 }

--- a/bluemix/trace/trace_test.go
+++ b/bluemix/trace/trace_test.go
@@ -3,7 +3,6 @@ package trace_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -100,7 +99,7 @@ func TestStdLogger(t *testing.T) {
 }
 
 func TestFileLogger(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 
 	defer f.Close()
@@ -111,14 +110,14 @@ func TestFileLogger(t *testing.T) {
 	logger.Printf("test %d", 100)
 	logger.Println("testln")
 
-	buf, err := ioutil.ReadAll(f)
+	buf, err := io.ReadAll(f)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "test\ntest 100\ntestln\n", string(buf))
 }
 
 func TestPrinterCloser(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(f.Name())
@@ -128,7 +127,7 @@ func TestPrinterCloser(t *testing.T) {
 	logger.Printf("test %d", 100)
 	logger.Println("testln")
 
-	buf, err := ioutil.ReadAll(f)
+	buf, err := io.ReadAll(f)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "test\ntest 100\ntestln\n", string(buf))

--- a/common/downloader/file_downloader_test.go
+++ b/common/downloader/file_downloader_test.go
@@ -2,7 +2,6 @@ package downloader
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -25,7 +24,7 @@ func TestDownloadTestSuite(t *testing.T) {
 }
 
 func (suite *DownloadTestSuite) SetupTest() {
-	tmpDir, err := ioutil.TempDir("", "testfiledownload")
+	tmpDir, err := os.MkdirTemp("", "testfiledownload")
 	suite.NoError(err)
 	suite.downloader = New(tmpDir)
 }

--- a/common/file_helpers/file.go
+++ b/common/file_helpers/file.go
@@ -4,7 +4,6 @@ package file_helpers
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -90,7 +89,7 @@ func CopyDir(src string, dest string) (err error) {
 		return
 	}
 
-	entries, err := ioutil.ReadDir(src)
+	entries, err := os.ReadDir(src)
 	if err != nil {
 		return
 	}
@@ -99,7 +98,7 @@ func CopyDir(src string, dest string) (err error) {
 		srcPath := filepath.Join(src, entry.Name())
 		destPath := filepath.Join(dest, entry.Name())
 
-		if entry.Mode().IsDir() {
+		if entry.IsDir() {
 			err = CopyDir(srcPath, destPath)
 		} else {
 			err = CopyFile(srcPath, destPath)

--- a/common/rest/client.go
+++ b/common/rest/client.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"gopkg.in/yaml.v2"
@@ -76,7 +75,7 @@ func (c *Client) DoWithContext(ctx context.Context, r *Request, respV interface{
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		raw, err := ioutil.ReadAll(resp.Body)
+		raw, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return resp, fmt.Errorf("Error reading response: %v", err)
 		}

--- a/common/rest/client_test.go
+++ b/common/rest/client_test.go
@@ -3,9 +3,9 @@ package rest
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -205,12 +205,12 @@ func TestDownloadFile(t *testing.T) {
 	ts := httptest.NewServer(serveHandler(200, "abcedefg"))
 	defer ts.Close()
 
-	f, err := ioutil.TempFile("", "BluemixCliRestTest")
+	f, err := os.CreateTemp("", "BluemixCliRestTest")
 	assert.NoError(err)
 	defer f.Close()
 
 	_, err = NewClient().Do(GetRequest(ts.URL), f, nil)
 	assert.NoError(err)
-	bytes, _ := ioutil.ReadFile(f.Name())
+	bytes, _ := os.ReadFile(f.Name())
 	assert.Equal("abcedefg", string(bytes))
 }

--- a/common/rest/helpers/client_helpers_test.go
+++ b/common/rest/helpers/client_helpers_test.go
@@ -2,7 +2,7 @@ package rest
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,7 +26,7 @@ func TestIsJSONStreamWithJSON(t *testing.T) {
 
 	assert.NotNil(r)
 
-	raw, _ := ioutil.ReadAll(r)
+	raw, _ := io.ReadAll(r)
 
 	assert.NotNil(raw)
 	assert.True(isJSON)
@@ -57,7 +57,7 @@ func TestIsJSONStreamWithJSONArray(t *testing.T) {
 
 	assert.NotNil(r)
 
-	raw, _ := ioutil.ReadAll(r)
+	raw, _ := io.ReadAll(r)
 
 	assert.NotNil(raw)
 	assert.True(isJSON)
@@ -80,7 +80,7 @@ func TestIsJSONStreamWithSpaceJSON(t *testing.T) {
 
 	assert.NotNil(r)
 
-	raw, _ := ioutil.ReadAll(r)
+	raw, _ := io.ReadAll(r)
 
 	assert.NotNil(raw)
 	assert.True(isJSON)
@@ -103,7 +103,7 @@ func TestIsJSONStreamWithInvalidJSON(t *testing.T) {
 
 	assert.NotNil(r)
 
-	raw, _ := ioutil.ReadAll(r)
+	raw, _ := io.ReadAll(r)
 
 	assert.NotNil(raw)
 	assert.False(isJSON)
@@ -121,7 +121,7 @@ func TestIsJSONStreamWithString(t *testing.T) {
 
 	assert.NotNil(r)
 
-	raw, _ := ioutil.ReadAll(r)
+	raw, _ := io.ReadAll(r)
 
 	assert.NotNil(raw)
 	assert.False(isJSON)
@@ -146,7 +146,7 @@ func TestIsJSONStreamWithYAML(t *testing.T) {
 
 	assert.NotNil(r)
 
-	raw, _ := ioutil.ReadAll(r)
+	raw, _ := io.ReadAll(r)
 
 	assert.NotNil(raw)
 	assert.False(isJSON)
@@ -172,7 +172,7 @@ func TestIsJSONStreamWithYamlArray(t *testing.T) {
 
 	assert.NotNil(r)
 
-	raw, _ := ioutil.ReadAll(r)
+	raw, _ := io.ReadAll(r)
 
 	assert.NotNil(raw)
 	assert.False(isJSON)
@@ -190,7 +190,7 @@ func TestIsJSONStreamWithEmptyString(t *testing.T) {
 
 	assert.NotNil(r)
 
-	raw, _ := ioutil.ReadAll(r)
+	raw, _ := io.ReadAll(r)
 
 	assert.NotNil(raw)
 	assert.False(isJSON)

--- a/plugin/plugin_config_test.go
+++ b/plugin/plugin_config_test.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,7 +29,7 @@ var (
 func TestPluginConfig_FileNotExist(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpDir, err := ioutil.TempDir("", "plugin_config_test")
+	tmpDir, err := os.MkdirTemp("", "plugin_config_test")
 	assert.NoError(err)
 
 	assert.NotPanics(func() {
@@ -330,13 +329,13 @@ func TestPluginConfigSet_AddNewKey(t *testing.T) {
 }
 
 func prepareConfigFile() string {
-	tmpDir, err := ioutil.TempDir("", "plugin_config_test")
+	tmpDir, err := os.MkdirTemp("", "plugin_config_test")
 	if err != nil {
 		panic("Failed to create temp dir:" + err.Error())
 	}
 
 	configFile := filepath.Join(tmpDir, "testConfig")
-	err = ioutil.WriteFile(configFile, []byte(config_string), 0600)
+	err = os.WriteFile(configFile, []byte(config_string), 0600)
 	if err != nil {
 		panic(err)
 	}

--- a/resources/i18n_resources.go
+++ b/resources/i18n_resources.go
@@ -14,7 +14,6 @@ package resources
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1580,7 +1579,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/testhelpers/command.go
+++ b/testhelpers/command.go
@@ -2,7 +2,6 @@ package testhelpers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -40,7 +39,7 @@ func CreateMockStdout() *mockStdoutFile {
 
 // Read will open the temp mock stdout file and return contents as a string
 func (m *mockStdoutFile) Read() string {
-	out, err := ioutil.ReadFile(m.File.Name())
+	out, err := os.ReadFile(m.File.Name())
 	if err != nil {
 		panic(fmt.Errorf("failed to read stdout file: %v", err.Error()))
 	}


### PR DESCRIPTION
The go.mod of this project requires Go 1.25.3 as minimum version. As such, one can replace all usages of the deprecated io/ioutil package with their documented replacements.

https://pkg.go.dev/io/ioutil