### PR TITLE
fix: ibmcloud binary name in examples

### DIFF
--- a/docs/interface_summary.md
+++ b/docs/interface_summary.md
@@ -98,7 +98,7 @@ NAME:
   group-update - Update an existing resource group
 
 USAGE:
-  icd resource group-update NAME [-n, --name NEW_NAME] [-f, --force] [--output FORMAT] [-q, --quiet]
+  ibmcloud resource group-update NAME [-n, --name NEW_NAME] [-f, --force] [--output FORMAT] [-q, --quiet]
 
 OPTIONS:
   -n value, --name value  New name of the resource group
@@ -133,7 +133,7 @@ NAME:
   group-update - Update an existing resource group
 
 USAGE:
-  icd resource group-update NAME [-n, --name NEW_NAME] [-f, --force] [--output FORMAT] [-q, --quiet]
+  ibmcloud resource group-update NAME [-n, --name NEW_NAME] [-f, --force] [--output FORMAT] [-q, --quiet]
 
 OPTIONS:
   -n value, --name value  New name of the resource group

--- a/docs/plugin_developer_guide.md
+++ b/docs/plugin_developer_guide.md
@@ -498,7 +498,7 @@ NAME:
   group-update - Update an existing resource group
 
 USAGE:
-  icd resource group-update NAME [-n, --name NEW_NAME] [-f, --force] [--output FORMAT] [-q, --quiet]
+  ibmcloud resource group-update NAME [-n, --name NEW_NAME] [-f, --force] [--output FORMAT] [-q, --quiet]
 
 OPTIONS:
   -n value, --name value  New name of the resource group
@@ -519,7 +519,7 @@ NAME:
   group-update - Update an existing resource group
 
 USAGE:
-  icd resource group-update NAME [-n, --name NEW_NAME] [-f, --force] [--output FORMAT] [-q, --quiet]
+  ibmcloud resource group-update NAME [-n, --name NEW_NAME] [-f, --force] [--output FORMAT] [-q, --quiet]
 
 OPTIONS:
   -n value, --name value  New name of the resource group


### PR DESCRIPTION
"icd" is not a valid shortname for the ibmcloud CLI.