### PR TITLE
feat: added configuration for PowerVS authentication

### DIFF
--- a/bluemix/authentication/vpc/vpc.go
+++ b/bluemix/authentication/vpc/vpc.go
@@ -9,13 +9,14 @@ import (
 )
 
 const (
-	DefaultMetadataServiceVersion = "2022-03-01"
-	DefaultServerEndpoint         = "http://169.254.169.254"
+	DefaultMetadataServiceVersion = "2025-08-26"
+	DefaultServerEndpoint         = "http://api.metadata.cloud.ibm.com"
+	DefaultPowerServerEndpoint    = "https://api.metadata.power-iaas.cloud.ibm.com"
 
-	defaultMetadataFlavor                 = "ibm"
+	DefaultMetadataFlavor                 = "ibm"
 	defaultInstanceIdentityTokenLifetime  = 300
-	defaultOperationPathCreateAccessToken = "/instance_identity/v1/token"
-	defaultOperationPathCreateIamToken    = "/instance_identity/v1/iam_token"
+	defaultOperationPathCreateAccessToken = "/identity/v1/token"
+	defaultOperationPathCreateIamToken    = "/identity/v1/iam_tokens"
 
 	// headers
 	MetadataFlavor = "Metadata-Flavor"
@@ -58,6 +59,7 @@ type Interface interface {
 
 type Config struct {
 	VPCAuthEndpoint              string
+	PVSAuthEndpoint              string
 	InstanceIdentiyTokenEndpoint string
 	IAMTokenEndpoint             string
 	Version                      string
@@ -106,12 +108,20 @@ func (c Config) instanceIdentityTokenEndpoint() string {
 	if c.InstanceIdentiyTokenEndpoint != "" {
 		return c.InstanceIdentiyTokenEndpoint
 	}
+
+	if c.PVSAuthEndpoint != "" {
+		return c.PVSAuthEndpoint + defaultOperationPathCreateAccessToken
+	}
 	return c.VPCAuthEndpoint + defaultOperationPathCreateAccessToken
 }
 
 func (c Config) iamTokenEndpoint() string {
 	if c.IAMTokenEndpoint != "" {
 		return c.IAMTokenEndpoint
+	}
+
+	if c.PVSAuthEndpoint != "" {
+		return c.PVSAuthEndpoint + defaultOperationPathCreateIamToken
 	}
 	return c.VPCAuthEndpoint + defaultOperationPathCreateIamToken
 }
@@ -122,6 +132,14 @@ func DefaultConfig(vpcAuthEndpoint string, apiVersion string) Config {
 		InstanceIdentiyTokenEndpoint: vpcAuthEndpoint + defaultOperationPathCreateAccessToken,
 		IAMTokenEndpoint:             vpcAuthEndpoint + defaultOperationPathCreateIamToken,
 		Version:                      apiVersion,
+	}
+}
+
+func PVSConfig(pvsAuthEndpoint string, apiVersion string) Config {
+	return Config{
+		PVSAuthEndpoint:              pvsAuthEndpoint,
+		InstanceIdentiyTokenEndpoint: pvsAuthEndpoint + defaultOperationPathCreateAccessToken,
+		IAMTokenEndpoint:             pvsAuthEndpoint + defaultOperationPathCreateIamToken,
 	}
 }
 
@@ -138,13 +156,17 @@ func NewClient(config Config, restClient *rest.Client) Interface {
 }
 
 // GetInstanceIdentityToken retrieves the VPC/VSI compute resource's instance identity token specified at
-// `c.config.VPCAuthEndpoint` using the "create_access_token" operation of the VPC Instance Metadata Service API.
+// `c.config.VPCAuthEndpoint` or `c.config.PVSAuthEndpoint` using the "create_access_token" operation of the VPC Instance Metadata Service API.
 func (c *client) GetInstanceIdentityToken() (*InstanceIdentityToken, error) {
 	req := rest.PutRequest(c.config.instanceIdentityTokenEndpoint())
 	// set headers
-	req.Set(MetadataFlavor, defaultMetadataFlavor)
+	req.Set(MetadataFlavor, DefaultMetadataFlavor)
 	// set query params
-	req.Query("version", c.config.Version)
+
+	// only VPC endpoint supports version query
+	if c.config.VPCAuthEndpoint != "" {
+		req.Query("version", c.config.Version)
+	}
 
 	// create body
 	body := fmt.Sprintf("{\"expires_in\": %d}", defaultInstanceIdentityTokenLifetime)
@@ -165,13 +187,20 @@ func (c *client) GetInstanceIdentityToken() (*InstanceIdentityToken, error) {
 }
 
 // GetIAMAccessToken exchanges the VPC/VSI compute resource's instance identity token for an IAM access token at
-// `c.config.VPCAuthEndpoint` using the "create_iam_token" operation of the VPC Instance Metadata Service API.
+// `c.config.VPCAuthEndpoint` or `c.config.PVSAuthEndpoint` using the "create_iam_token" operation of the VPC Instance Metadata Service API.
 // The request body can consist of a profile CRN or ID, but not both.
 func (c *client) GetIAMAccessToken(tokenReq *IAMAccessTokenRequest) (*iam.Token, error) {
 	req := rest.PostRequest(c.config.iamTokenEndpoint())
 	// set instance identity token
 	req.Set(authorization, "Bearer "+tokenReq.AccessToken)
-	req.Query("version", c.config.Version)
+
+	// // NOTE: Only VPC supports version
+	// PowerVS require the Metadata-Flavor request header
+	if c.config.PVSAuthEndpoint != "" {
+		req.Set(MetadataFlavor, DefaultMetadataFlavor)
+	} else {
+		req.Query("version", c.config.Version)
+	}
 
 	if tokenReq.Body != nil {
 		var body string

--- a/bluemix/authentication/vpc/vpc_test.go
+++ b/bluemix/authentication/vpc/vpc_test.go
@@ -32,9 +32,19 @@ var currentTime time.Time = time.Now()
 func TestDefaultConfig(t *testing.T) {
 	config := vpc.DefaultConfig("http://mockUrl", vpc.DefaultMetadataServiceVersion)
 	assert.Equal(t, "http://mockUrl", config.VPCAuthEndpoint)
-	assert.Equal(t, "http://mockUrl/instance_identity/v1/token", config.InstanceIdentiyTokenEndpoint)
-	assert.Equal(t, "http://mockUrl/instance_identity/v1/iam_token", config.IAMTokenEndpoint)
+	assert.Equal(t, "http://mockUrl/identity/v1/token", config.InstanceIdentiyTokenEndpoint)
+	assert.Equal(t, "http://mockUrl/identity/v1/iam_tokens", config.IAMTokenEndpoint)
 	assert.Equal(t, vpc.DefaultMetadataServiceVersion, config.Version)
+
+}
+
+func TestPVSConfig(t *testing.T) {
+	config := vpc.PVSConfig("http://mockUrl", vpc.DefaultMetadataServiceVersion)
+	assert.Equal(t, "http://mockUrl", config.PVSAuthEndpoint)
+	assert.Empty(t, config.VPCAuthEndpoint)
+	assert.Equal(t, "http://mockUrl/identity/v1/token", config.InstanceIdentiyTokenEndpoint)
+	assert.Equal(t, "http://mockUrl/identity/v1/iam_tokens", config.IAMTokenEndpoint)
+	assert.Equal(t, "", config.Version)
 
 }
 func TestIAMAccessTokenRequestWithProfileID(t *testing.T) {
@@ -84,7 +94,7 @@ func TestIAMAccessTokenRequestFailure(t *testing.T) {
 }
 
 func TestGetInstanceIdentiyTokenSuccess(t *testing.T) {
-	server := startMockVPCServerForTokenExchange(t, http.StatusOK, false, false, true)
+	server := startMockVPCServerForTokenExchange(t, http.StatusOK, false, false, true, false)
 	defer server.Close()
 
 	mockServerEndpoint := server.URL
@@ -106,7 +116,7 @@ func TestGetInstanceIdentiyTokenSuccess(t *testing.T) {
 }
 
 func TestGetInstanceIdentiyTokenFailure(t *testing.T) {
-	server := startMockVPCServerForTokenExchange(t, http.StatusUnauthorized, false, false, true)
+	server := startMockVPCServerForTokenExchange(t, http.StatusUnauthorized, false, false, true, false)
 	defer server.Close()
 
 	mockServerEndpoint := server.URL
@@ -121,7 +131,7 @@ func TestGetInstanceIdentiyTokenFailure(t *testing.T) {
 }
 
 func TestGetIAMAccessTokenSuccessWProfileID(t *testing.T) {
-	server := startMockVPCServerForTokenExchange(t, http.StatusOK, false, true, true)
+	server := startMockVPCServerForTokenExchange(t, http.StatusOK, false, true, true, false)
 	defer server.Close()
 
 	mockServerEndpoint := server.URL
@@ -152,7 +162,7 @@ func TestGetIAMAccessTokenSuccessWProfileID(t *testing.T) {
 }
 
 func TestGetIAMAccessTokenSuccessWithoutBody1(t *testing.T) {
-	server := startMockVPCServerForTokenExchange(t, http.StatusOK, false, false, false)
+	server := startMockVPCServerForTokenExchange(t, http.StatusOK, false, false, false, false)
 	defer server.Close()
 
 	mockServerEndpoint := server.URL
@@ -184,7 +194,7 @@ func TestGetIAMAccessTokenSuccessWithoutBody1(t *testing.T) {
 }
 
 func TestGetIAMAccessTokenSuccessWithoutBody2(t *testing.T) {
-	server := startMockVPCServerForTokenExchange(t, http.StatusOK, false, false, false)
+	server := startMockVPCServerForTokenExchange(t, http.StatusOK, false, false, false, false)
 	defer server.Close()
 
 	mockServerEndpoint := server.URL
@@ -215,7 +225,7 @@ func TestGetIAMAccessTokenSuccessWithoutBody2(t *testing.T) {
 }
 
 func TestGetIAMAccessTokenFailureWProfileID(t *testing.T) {
-	server := startMockVPCServerForTokenExchange(t, http.StatusBadRequest, false, true, true)
+	server := startMockVPCServerForTokenExchange(t, http.StatusBadRequest, false, true, true, false)
 	defer server.Close()
 
 	mockServerEndpoint := server.URL
@@ -242,7 +252,7 @@ func TestGetIAMAccessTokenFailureWProfileID(t *testing.T) {
 }
 
 func TestGetIAMAccessTokenSuccessWProfileCRN(t *testing.T) {
-	server := startMockVPCServerForTokenExchange(t, http.StatusOK, true, false, true)
+	server := startMockVPCServerForTokenExchange(t, http.StatusOK, true, false, true, false)
 	defer server.Close()
 
 	mockServerEndpoint := server.URL
@@ -274,7 +284,7 @@ func TestGetIAMAccessTokenSuccessWProfileCRN(t *testing.T) {
 }
 
 func TestGetIAMAccessTokenFailureWProfileCRN(t *testing.T) {
-	server := startMockVPCServerForTokenExchange(t, http.StatusBadRequest, true, false, true)
+	server := startMockVPCServerForTokenExchange(t, http.StatusBadRequest, true, false, true, false)
 	defer server.Close()
 
 	mockServerEndpoint := server.URL
@@ -303,12 +313,12 @@ func TestGetIAMAccessTokenFailureWProfileCRN(t *testing.T) {
 
 // startMockIAMServerForCRExchange will start a mock server endpoint that supports both the
 // VPC operations for exchanging an instance identity token and an IAM TOKEN.
-func startMockVPCServerForTokenExchange(t *testing.T, statusCode int, withCRN bool, withID bool, containsBody bool) *httptest.Server {
+func startMockVPCServerForTokenExchange(t *testing.T, statusCode int, withCRN bool, withID bool, containsBody bool, isPVS bool) *httptest.Server {
 	// Create the mock server.
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		operationPath := req.URL.EscapedPath()
 
-		if operationPath == "/instance_identity/v1/token" {
+		if operationPath == "/identity/v1/token" {
 			// If this is an invocation of the VPC "create_access_token" operation,
 			// then validate it and then send back a good response.
 			assert.Equal(t, applicationJson, req.Header.Get("Accept"))
@@ -318,7 +328,11 @@ func startMockVPCServerForTokenExchange(t *testing.T, statusCode int, withCRN bo
 			query := req.URL.Query()
 			version := query.Get("version")
 
-			assert.Equal(t, vpc.DefaultMetadataServiceVersion, version)
+			if isPVS {
+				assert.Equal(t, "", version)
+			} else {
+				assert.Equal(t, vpc.DefaultMetadataServiceVersion, version)
+			}
 			// validate request body
 			type createAccessTokenRequestBody struct {
 				// Time in seconds before the access token expires.
@@ -327,7 +341,10 @@ func startMockVPCServerForTokenExchange(t *testing.T, statusCode int, withCRN bo
 			// Unmarshal the request body.
 			requestBody := &createAccessTokenRequestBody{}
 			_ = json.NewDecoder(req.Body).Decode(requestBody)
-			defer req.Body.Close()
+			defer func() {
+				err := req.Body.Close()
+				assert.Nil(t, err)
+			}()
 			assert.NotNil(t, requestBody.ExpiresIn)
 
 			expiration := currentTime.Add(time.Second * 300).UTC().Format(time.RFC3339)
@@ -335,15 +352,18 @@ func startMockVPCServerForTokenExchange(t *testing.T, statusCode int, withCRN bo
 			res.WriteHeader(statusCode)
 			switch statusCode {
 			case http.StatusOK:
-				fmt.Fprintf(res, `{"access_token": "%s", "created_at": "%s", "expires_at": "%s", "expires_in": 300}`,
+				_, err := fmt.Fprintf(res, `{"access_token": "%s", "created_at": "%s", "expires_at": "%s", "expires_in": 300}`,
 					instanceIdentityToken, time.Now().String(), expiration)
+				assert.Nil(t, err)
 			case http.StatusBadRequest:
-				fmt.Fprintf(res, `Sorry, bad request!`)
+				_, err := fmt.Fprintf(res, `Sorry, bad request!`)
+				assert.Nil(t, err)
 
 			case http.StatusUnauthorized:
-				fmt.Fprintf(res, `Sorry, you are not authorized!`)
+				_, err := fmt.Fprintf(res, `Sorry, you are not authorized!`)
+				assert.Nil(t, err)
 			}
-		} else if operationPath == "/instance_identity/v1/iam_token" {
+		} else if operationPath == "/identity/v1/iam_tokens" {
 			// If this is an invocation of the VPC "create_iam_token" operation,
 			// then validate it and then send back a good response.
 			assert.Equal(t, applicationJson, req.Header.Get("Accept"))
@@ -356,14 +376,22 @@ func startMockVPCServerForTokenExchange(t *testing.T, statusCode int, withCRN bo
 			query := req.URL.Query()
 			version := query.Get("version")
 
-			assert.Equal(t, vpc.DefaultMetadataServiceVersion, version)
+			if isPVS {
+				assert.Equal(t, "", version)
+				assert.Equal(t, vpc.DefaultMetadataFlavor, req.Header.Get(vpc.MetadataFlavor))
+			} else {
+				assert.Equal(t, vpc.DefaultMetadataServiceVersion, version)
+			}
 			// Models the request body for the 'create_iam_token' operation.
 			type createIamTokenRequestBody struct {
 				TrustedProfile *vpc.TrustedProfileByIdOrCRN `json:"trusted_profile,omitempty"`
 			}
 			requestBody := &createIamTokenRequestBody{}
 			_ = json.NewDecoder(req.Body).Decode(requestBody)
-			defer req.Body.Close()
+			defer func() {
+				err := req.Body.Close()
+				assert.Nil(t, err)
+			}()
 
 			if withID {
 				assert.NotNil(t, requestBody.TrustedProfile.ID)
@@ -381,13 +409,16 @@ func startMockVPCServerForTokenExchange(t *testing.T, statusCode int, withCRN bo
 			res.WriteHeader(statusCode)
 			switch statusCode {
 			case http.StatusOK:
-				fmt.Fprintf(res, `{"access_token": "%s", "created_at": "%s", "expires_at": "%s", "expires_in": 3600}`,
+				_, err := fmt.Fprintf(res, `{"access_token": "%s", "created_at": "%s", "expires_at": "%s", "expires_in": 3600}`,
 					iamAccessToken, time.Now().String(), expiration)
+				assert.Nil(t, err)
 			case http.StatusBadRequest:
-				fmt.Fprintf(res, `Sorry, bad request!`)
+				_, err := fmt.Fprintf(res, `Sorry, bad request!`)
+				assert.Nil(t, err)
 
 			case http.StatusUnauthorized:
-				fmt.Fprintf(res, `Sorry, you are not authorized!`)
+				_, err := fmt.Fprintf(res, `Sorry, you are not authorized!`)
+				assert.Nil(t, err)
 			}
 		} else {
 			assert.Fail(t, "unknown operation path: "+operationPath)

--- a/bluemix/configuration/core_config/repository.go
+++ b/bluemix/configuration/core_config/repository.go
@@ -66,6 +66,9 @@ type Repository interface {
 	// VPCCRITokenURL() returns the value specified by the environment variable 'IBMCLOUD_CR_VPC_URL', if set.
 	// Otherwise, the default VPC auth url specified by the constant `DefaultServerEndpoint` is returned
 	VPCCRITokenURL() string
+	// PVSCCRITokenURL() returns the value specified by the environment variable 'IBMCLOUD_CR_PVS_URL', if set.
+	// Otherwise, the default VPC auth url specified by the constant `DefaultPowerEndpoint` is returned
+	PVSCRITokenURL() string
 
 	// UsageSatsDisabled returns whether the usage statistics data collection is disabled or not
 	// Deprecated: use UsageSatsEnabled instead. We change to disable usage statistics by default,
@@ -171,6 +174,15 @@ func (c repository) VPCCRITokenURL() string {
 	return vpc.DefaultServerEndpoint
 }
 
+func (c repository) PVSCRITokenURL() string {
+	if env := bluemix.EnvCRPvsUrl.Get(); env != "" {
+		return env
+	}
+
+	// default power endpoint is a constant value in vpc authenticator
+	return vpc.DefaultPowerServerEndpoint
+}
+
 func (c repository) IAMEndpoint() string {
 	if c.IsPrivateEndpointEnabled() {
 		if c.IsAccessFromVPC() {
@@ -189,7 +201,7 @@ func (c repository) RefreshIAMToken() (string, error) {
 	// confirm user is logged in as a VPC compute resource identity
 	isLoggedInAsCRI := c.IsLoggedInAsCRI()
 	criType := c.CRIType()
-	if isLoggedInAsCRI && criType == "VPC" {
+	if isLoggedInAsCRI && (criType == "VPC" || criType == "PVS") {
 		token, err := c.fetchNewIAMTokenUsingVPCAuth()
 		if err != nil {
 			return "", err
@@ -225,8 +237,14 @@ func (c repository) RefreshIAMToken() (string, error) {
 }
 
 func (c repository) fetchNewIAMTokenUsingVPCAuth() (*iam.Token, error) {
-	// create a vpc client using default configuration
-	client := vpc.NewClient(vpc.DefaultConfig(c.VPCCRITokenURL(), vpc.DefaultMetadataServiceVersion), rest.NewClient())
+	criType := c.CRIType()
+	config := vpc.DefaultConfig(c.VPCCRITokenURL(), vpc.DefaultMetadataServiceVersion)
+
+	if criType == "PVS" {
+		config = vpc.PVSConfig(c.PVSCRITokenURL(), vpc.DefaultMetadataServiceVersion)
+	}
+	// create a vpc client using default or pvc configuration
+	client := vpc.NewClient(config, rest.NewClient())
 	// fetch an instance identity token from the metadata server
 	identityToken, err := client.GetInstanceIdentityToken()
 	if err != nil {

--- a/bluemix/env.go
+++ b/bluemix/env.go
@@ -23,6 +23,8 @@ var (
 	EnvCRProfile = newEnv("IBMCLOUD_CR_PROFILE")
 	// EnvCRVpcUrl is the environment variable `IBMCLOUD_CR_VPC_URL`
 	EnvCRVpcUrl = newEnv("IBMCLOUD_CR_VPC_URL")
+	// EnvCRPvsUrl is the environment variable `IBMCLOUD_CR_PVS_URL`
+	EnvCRPvsUrl = newEnv("IBMCLOUD_CR_PVS_URL")
 	// EnvConfigHome is the environment variable `IBMCLOUD_HOME` and `BLUEMIX_HOME` (deprecated)
 	EnvConfigHome = newEnv("IBMCLOUD_HOME", "BLUEMIX_HOME")
 	// EnvConfigDir is the environment variable `IBMCLOUD_CONFIG_HOME`


### PR DESCRIPTION
# Context

The PR will add configuration to authenticated against PowerVS. The configuration uses the same authentication as VPC.

# Callouts
- There has been a change in VPC endpoints that require us to update the paths and versioning. See [Updating to the 2025-08-26 version of the VPC Identity API](https://cloud.ibm.com/docs/vpc?topic=vpc-2025-08-26-migration-metadata-identity) for more information
    - These changes will not impact existing and current customers since the backend has moved to this new endpoint
