### PR TITLE
chore: added detect secrets pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# This is an example configuration to enable detect-secrets in the pre-commit hook.
+# Add this file to the root folder of your repository.
+#
+# Read pre-commit hook framework https://pre-commit.com/ for more details about the structure of config yaml file and how git pre-commit would invoke each hook.
+#
+# This line indicates we will use the hook from ibm/detect-secrets to run scan during committing phase.
+repos:
+  - repo: https://github.com/ibm/detect-secrets
+    # If you desire to use a specific version of detect-secrets, you can replace `master` with other git revisions such as branch, tag or commit sha.
+    # You are encouraged to use static refs such as tags, instead of branch name
+    #
+    # Running "pre-commit autoupdate" automatically updates rev to latest tag
+    rev: 0.13.1+ibm.64.dss
+    hooks:
+      - id: detect-secrets # pragma: whitelist secret
+        # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.
+        # You may also run `pre-commit run detect-secrets` to preview the scan result.
+        # when "--baseline" without "--use-all-plugins", pre-commit scan with just plugins in baseline file
+        # when "--baseline" with "--use-all-plugins", pre-commit scan with all available plugins
+        # add "--fail-on-unaudited" to fail pre-commit for unaudited potential secrets
+        args: [--baseline, .secrets.baseline, --use-all-plugins, --fail-on-unaudited]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$|go.sum|.nancy-ignore",
     "lines": null
   },
-  "generated_at": "2025-01-10T15:55:19Z",
+  "generated_at": "2026-06-22T20:58:53Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -320,7 +320,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.62.dss",
+  "version": "0.13.1+ibm.64.dss",
   "word_list": {
     "file": null,
     "hash": null


### PR DESCRIPTION
# Context

This PR will add configuration that will executed detect-secrets on pre-commit. The developer is responsible for installing the pre-commit package and installing the hook.

Installation and steps are described in the CONTRIBUTOR.md
# What was tested?

**Install the precommit and test** 
1. Install the precommit python package: `pip install pre-commit`
2. Install the hook: `pre-commit install`
3. Verify that the hook is installed successfully
4. Create a commit and verify that the commit goes through (it may fail if you using an older version of the tool)
