### PR TITLE
chore: added dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates: 
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "dev"


### PR DESCRIPTION
# Context

This PR will add configuration to set dependabot to use `dev` instead of main branch
