### PR TITLE
fix: plugin validate accept flags with lists

### DIFF
--- a/plugin/plugin_metadata_validator.go
+++ b/plugin/plugin_metadata_validator.go
@@ -616,18 +616,20 @@ func validatePositionalArguments(sl validator.StructLevel) {
 	//   e.g. "json|text|yaml"  or  "(classic|vpc-gen2)"  or  "[ a | b ]"
 	const pipeList = `[\(\[]?\s*` + pipeListItem + `(?:\s*\|\s*` + pipeListItem + `)+\s*[\)\]]?`
 
-	// longFlag matches a long flag name, optionally followed by a pipe-list value.
-	//   e.g. "--output"  or  "--output json|text|yaml"
+	// longFlag matches a long flag name (letters, digits, hyphens), optionally followed by a
+	// pipe-list value.
+	//   e.g. "--output"  or  "--output json|text|yaml"  or  "--tls-1-3 (on|off)"
 	//   A single bare word after the flag is NOT consumed so that "--name instance" is still caught.
-	const longFlag = `--[a-zA-Z][a-zA-Z-]*(?:\s+` + pipeList + `)?`
+	const longFlag = `--[a-zA-Z][a-zA-Z0-9-]*(?:\s+` + pipeList + `)?`
 
 	// shortFlagWithList matches a short flag followed by a pipe-list value (space consumed by flag).
-	//   e.g. "-o classic|vpc-gen2"
-	const shortFlagWithList = `-[a-zA-Z]\s+` + pipeList
+	// Also handles the "-f, --long VALUE" alias style where a comma follows the short flag.
+	//   e.g. "-o classic|vpc-gen2"  or  "-i, --instance" (comma eaten; --instance handled by longFlag)
+	const shortFlagWithList = `-[a-zA-Z][,\s]\s*` + pipeList
 
-	// shortFlag matches a short flag that consumes its trailing space but has no pipe-list.
-	//   e.g. "-f "  (kept last so shortFlagWithList takes priority)
-	const shortFlag = `-[a-zA-Z]\s+`
+	// shortFlag matches a short flag that consumes its trailing space or comma but has no pipe-list.
+	//   e.g. "-f "  or  "-i, "  (kept last so shortFlagWithList takes priority)
+	const shortFlag = `-[a-zA-Z][,\s]\s*`
 
 	flagPipeListPattern := regexp.MustCompile(longFlag + `|` + shortFlagWithList + `|` + shortFlag)
 	usageWithoutFlags := flagPipeListPattern.ReplaceAllString(usageText, "")
@@ -635,9 +637,13 @@ func validatePositionalArguments(sl validator.StructLevel) {
 	// Remove file paths to avoid flagging path components like /usr/local/bin
 	usageWithoutPaths := regexp.MustCompile(`/[a-z/]+`).ReplaceAllString(usageWithoutFlags, "")
 
-	// Match lowercase words (2+ chars, may contain hyphens/underscores)
-	// Use word boundaries to properly match words
-	// This will match lowercase words even inside choice operators like (option_a | OPTION_B)
+	// Match lowercase words (2+ chars, may contain hyphens/underscores).
+	// Uses word boundaries to properly match words, including those inside choice operators
+	// like (option_a | OPTION_B).
+	// TODO: digits are excluded from this character class, so a token like "my-db-1" is split
+	// at the digit boundary and only "my-db" is flagged. Values that mix letters and digits
+	// (e.g. example zone names like "us-south-1a") may produce noisy or missed matches.
+	// Consider whether digit-containing tokens should be excluded from flagging entirely.
 	paramPattern := regexp.MustCompile(`\b([a-z][a-z_-]+)\b`)
 	matches := paramPattern.FindAllStringSubmatch(usageWithoutPaths, -1)
 	var lowercaseParams []string

--- a/plugin/plugin_metadata_validator.go
+++ b/plugin/plugin_metadata_validator.go
@@ -640,10 +640,9 @@ func validatePositionalArguments(sl validator.StructLevel) {
 	// Match lowercase words (2+ chars, may contain hyphens/underscores).
 	// Uses word boundaries to properly match words, including those inside choice operators
 	// like (option_a | OPTION_B).
-	// TODO: digits are excluded from this character class, so a token like "my-db-1" is split
+	// NOTE: digits are excluded from this character class, so a token like "my-db-1" is split
 	// at the digit boundary and only "my-db" is flagged. Values that mix letters and digits
 	// (e.g. example zone names like "us-south-1a") may produce noisy or missed matches.
-	// Consider whether digit-containing tokens should be excluded from flagging entirely.
 	paramPattern := regexp.MustCompile(`\b([a-z][a-z_-]+)\b`)
 	matches := paramPattern.FindAllStringSubmatch(usageWithoutPaths, -1)
 	var lowercaseParams []string

--- a/plugin/plugin_metadata_validator.go
+++ b/plugin/plugin_metadata_validator.go
@@ -599,9 +599,24 @@ func validatePositionalArguments(sl validator.StructLevel) {
 	// Filter out common words, command names, and words that are part of the command structure
 	// Strategy: Find lowercase words including those in choice operators, but exclude flags and paths
 
-	// Remove flag names (words after --) to avoid false positives
-	// Flags like --name, --zone, --tags or -a, -A should not be flagged
-	usageWithoutFlags := regexp.MustCompile(`(-[a-zA-Z]{1}\s+)|(--[a-zA-Z][a-zA-Z-]*)`).ReplaceAllString(usageText, "")
+	// Remove flag names (and any pipe-list values that follow them) to avoid false positives.
+	// Flags like --name, --zone, --tags or -a, -A should not be flagged.
+	// A pipe-list after a flag (e.g. --output json|text|yaml or --provider (classic|vpc-gen2))
+	// contains literal enum values, not user-input placeholders, so they are also stripped.
+	// Single bare words after a flag (e.g. --flag value) are intentionally NOT stripped here
+	// so that missing-caps placeholders like --name instance are still caught.
+	// Two patterns are needed because short flags (-f) already consume a trailing space in the
+	// original behaviour, so the pipe-list must be appended differently for each form.
+	flagPipeListPattern := regexp.MustCompile(
+		// Long flag: --flag optionally followed by a pipe-list value
+		`--[a-zA-Z][a-zA-Z-]*` +
+			`(?:\s+[\(\[]?\s*[a-zA-Z0-9][a-zA-Z0-9_-]*(?:\s*\|\s*[a-zA-Z0-9][a-zA-Z0-9_-]*)+\s*[\)\]]?)?` +
+			// Short flag: -f<space> optionally followed by a pipe-list value (space already consumed)
+			`|-[a-zA-Z]\s+[\(\[]?\s*[a-zA-Z0-9][a-zA-Z0-9_-]*(?:\s*\|\s*[a-zA-Z0-9][a-zA-Z0-9_-]*)+\s*[\)\]]?` +
+			// Short flag with no pipe-list value (original behaviour, kept last so the above takes priority)
+			`|-[a-zA-Z]\s+`,
+	)
+	usageWithoutFlags := flagPipeListPattern.ReplaceAllString(usageText, "")
 
 	// Remove file paths to avoid flagging path components like /usr/local/bin
 	usageWithoutPaths := regexp.MustCompile(`/[a-z/]+`).ReplaceAllString(usageWithoutFlags, "")

--- a/plugin/plugin_metadata_validator.go
+++ b/plugin/plugin_metadata_validator.go
@@ -607,15 +607,29 @@ func validatePositionalArguments(sl validator.StructLevel) {
 	// so that missing-caps placeholders like --name instance are still caught.
 	// Two patterns are needed because short flags (-f) already consume a trailing space in the
 	// original behaviour, so the pipe-list must be appended differently for each form.
-	flagPipeListPattern := regexp.MustCompile(
-		// Long flag: --flag optionally followed by a pipe-list value
-		`--[a-zA-Z][a-zA-Z-]*` +
-			`(?:\s+[\(\[]?\s*[a-zA-Z0-9][a-zA-Z0-9_-]*(?:\s*\|\s*[a-zA-Z0-9][a-zA-Z0-9_-]*)+\s*[\)\]]?)?` +
-			// Short flag: -f<space> optionally followed by a pipe-list value (space already consumed)
-			`|-[a-zA-Z]\s+[\(\[]?\s*[a-zA-Z0-9][a-zA-Z0-9_-]*(?:\s*\|\s*[a-zA-Z0-9][a-zA-Z0-9_-]*)+\s*[\)\]]?` +
-			// Short flag with no pipe-list value (original behaviour, kept last so the above takes priority)
-			`|-[a-zA-Z]\s+`,
-	)
+
+	// pipeListItem matches one token in a pipe-separated list: alphanumeric plus hyphens/underscores.
+	//   e.g. "json", "vpc-gen2", "my_value"
+	const pipeListItem = `[a-zA-Z0-9][a-zA-Z0-9_-]*`
+
+	// pipeList matches two or more pipe-separated tokens, with optional surrounding ( ) or [ ].
+	//   e.g. "json|text|yaml"  or  "(classic|vpc-gen2)"  or  "[ a | b ]"
+	const pipeList = `[\(\[]?\s*` + pipeListItem + `(?:\s*\|\s*` + pipeListItem + `)+\s*[\)\]]?`
+
+	// longFlag matches a long flag name, optionally followed by a pipe-list value.
+	//   e.g. "--output"  or  "--output json|text|yaml"
+	//   A single bare word after the flag is NOT consumed so that "--name instance" is still caught.
+	const longFlag = `--[a-zA-Z][a-zA-Z-]*(?:\s+` + pipeList + `)?`
+
+	// shortFlagWithList matches a short flag followed by a pipe-list value (space consumed by flag).
+	//   e.g. "-o classic|vpc-gen2"
+	const shortFlagWithList = `-[a-zA-Z]\s+` + pipeList
+
+	// shortFlag matches a short flag that consumes its trailing space but has no pipe-list.
+	//   e.g. "-f "  (kept last so shortFlagWithList takes priority)
+	const shortFlag = `-[a-zA-Z]\s+`
+
+	flagPipeListPattern := regexp.MustCompile(longFlag + `|` + shortFlagWithList + `|` + shortFlag)
 	usageWithoutFlags := flagPipeListPattern.ReplaceAllString(usageText, "")
 
 	// Remove file paths to avoid flagging path components like /usr/local/bin

--- a/plugin/plugin_metadata_validator_usage_test.go
+++ b/plugin/plugin_metadata_validator_usage_test.go
@@ -524,6 +524,114 @@ func TestValidateUsageEnhanced_LowercaseArguments(t *testing.T) {
 	}
 }
 
+// TestValidateUsageEnhanced_FlagPipeListExemption tests that pipe-separated literal
+// enum values attached to a flag are NOT flagged as lowercase argument placeholders.
+func TestValidateUsageEnhanced_FlagPipeListExemption(t *testing.T) {
+	validator := NewPluginMetadataValidator()
+
+	baseMetadata := func(usage string) []PluginMetadata {
+		return []PluginMetadata{
+			{
+				Name:          "plugin",
+				Version:       VersionType{Major: 1},
+				MinCliVersion: VersionType{Major: 2},
+				Namespaces:    []Namespace{{ParentName: "", Name: "ibmcloud"}},
+				Commands: []Command{
+					{
+						Namespace:   "sl",
+						Name:        "vs-create",
+						Description: "Create a virtual server",
+						Usage:       usage,
+						Flags:       []Flag{},
+					},
+				},
+			},
+		}
+	}
+
+	noErrorCases := []struct {
+		name  string
+		usage string
+	}{
+		{
+			name:  "bare pipe-list after flag",
+			usage: "ibmcloud sl vs-create NAME --output json|text|yaml",
+		},
+		{
+			name:  "bare pipe-list after flag with spaces around pipes",
+			usage: "ibmcloud sl vs-create NAME --output json | text | yaml",
+		},
+		{
+			name:  "parenthesised pipe-list after flag",
+			usage: "ibmcloud sl vs-create NAME --output (json|text|yaml)",
+		},
+		{
+			name:  "parenthesised pipe-list with spaces after flag",
+			usage: "ibmcloud sl vs-create NAME --output (json | text | yaml)",
+		},
+		{
+			name:  "bracketed pipe-list after flag",
+			usage: "ibmcloud sl vs-create NAME --provider [classic|vpc-gen2]",
+		},
+		{
+			name:  "multiple flags each with a pipe-list",
+			usage: "ibmcloud sl vs-create NAME --output json|text --provider classic|vpc-gen2",
+		},
+		{
+			name:  "short flag with pipe-list",
+			usage: "ibmcloud sl vs-create NAME -o json|text|yaml",
+		},
+	}
+
+	for _, tc := range noErrorCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pluginToErrors := validator.Errors(baseMetadata(tc.usage))
+			for _, errs := range pluginToErrors {
+				for _, err := range errs {
+					assert.False(t,
+						containsString(err.Error, "lowercase argument values"),
+						"Flag pipe-list values should not be flagged as lowercase args in: %s\ngot: %s",
+						tc.usage, err.Error,
+					)
+				}
+			}
+		})
+	}
+
+	// A missing-caps placeholder after a flag must still be caught.
+	t.Run("single bare lowercase after flag is still caught", func(t *testing.T) {
+		usage := "ibmcloud sl vs-create NAME --zone us-south-1a"
+		pluginToErrors := validator.Errors(baseMetadata(usage))
+		found := false
+		for _, errs := range pluginToErrors {
+			for _, err := range errs {
+				if containsString(err.Error, "lowercase argument values") {
+					found = true
+				}
+			}
+		}
+		assert.True(t, found, "Expected capargs warning for missing-caps placeholder in: %s", usage)
+	})
+
+	// A positional choice group that is NOT behind a flag must still be validated.
+	t.Run("positional pipe-list with lowercase is still caught", func(t *testing.T) {
+		usage := "ibmcloud sl vs-create NAME (option_a | OPTION_B)"
+		pluginToErrors := validator.Errors(baseMetadata(usage))
+		found := false
+		for _, errs := range pluginToErrors {
+			for _, err := range errs {
+				if containsString(err.Error, "lowercase argument values") &&
+					containsString(err.Error, "option_a") {
+					found = true
+				}
+			}
+		}
+		assert.True(t, found, "Expected capargs warning for lowercase positional choice in: %s", usage)
+	})
+}
+
+
+
 // TestValidateUsageEnhanced_ExcludedWords tests that command words are not flagged as lowercase arguments
 func TestValidateUsageEnhanced_ExcludedWords(t *testing.T) {
 	validator := NewPluginMetadataValidator()

--- a/plugin/plugin_metadata_validator_usage_test.go
+++ b/plugin/plugin_metadata_validator_usage_test.go
@@ -581,6 +581,36 @@ func TestValidateUsageEnhanced_FlagPipeListExemption(t *testing.T) {
 			name:  "short flag with pipe-list",
 			usage: "ibmcloud sl vs-create NAME -o json|text|yaml",
 		},
+		{
+			// Flag names containing digits (e.g. --tls-1-3) must be fully stripped.
+			name:  "long flag with digits in name and parenthesised pipe-list",
+			usage: "ibmcloud sl vs-create NAME --tls-1-3 (on|off)",
+		},
+		{
+			name:  "long flag with digits in name and bare pipe-list",
+			usage: "ibmcloud sl vs-create NAME --tls-1-2-only (on|off) --tls-1-3 (on|off)",
+		},
+		{
+			// Short flags in "-q, --quiet" alias style: the comma must not leave
+			// the long flag name behind as a lowercase word.
+			name:  "short flag with comma alias, no value",
+			usage: "ibmcloud sl vs-create NAME [-q, --quiet]",
+		},
+		{
+			// Short flag in alias style followed by a pipe-list value.
+			name:  "short flag with comma alias and pipe-list",
+			usage: "ibmcloud sl vs-create NAME [-i, --instance INSTANCE] [--output json|text|yaml]",
+		},
+		{
+			// true | false after a flag is a literal enum, not a user placeholder.
+			name:  "true | false pipe-list after long flag",
+			usage: "ibmcloud sl vs-create NAME --metadata-service true | false",
+		},
+		{
+			// enable | disable style common in VPC/PI commands.
+			name:  "enable | disable pipe-list after long flag",
+			usage: "ibmcloud sl vs-create NAME --advertise enable | disable",
+		},
 	}
 
 	for _, tc := range noErrorCases {
@@ -597,6 +627,39 @@ func TestValidateUsageEnhanced_FlagPipeListExemption(t *testing.T) {
 			}
 		})
 	}
+
+	// Real-world CIS pattern: digits in flag name + parenthesised pipe-list + short/long alias
+	// pair. Uses matching namespace/name so command words are correctly excluded.
+	t.Run("cis tls-settings-update style line", func(t *testing.T) {
+		usage := "ibmcloud cis tls-settings-update DNS_DOMAIN_ID [--tls-1-2-only (on|off)] [--tls-1-3 (on|off)] [-i, --instance INSTANCE] [--output FORMAT]"
+		metadata := []PluginMetadata{
+			{
+				Name:          "plugin",
+				Version:       VersionType{Major: 1},
+				MinCliVersion: VersionType{Major: 2},
+				Namespaces:    []Namespace{{ParentName: "", Name: "ibmcloud"}},
+				Commands: []Command{
+					{
+						Namespace:   "cis",
+						Name:        "tls-settings-update",
+						Description: "Update TLS settings",
+						Usage:       usage,
+						Flags:       []Flag{},
+					},
+				},
+			},
+		}
+		pluginToErrors := validator.Errors(metadata)
+		for _, errs := range pluginToErrors {
+			for _, err := range errs {
+				assert.False(t,
+					containsString(err.Error, "lowercase argument values"),
+					"Flag pipe-list values should not be flagged as lowercase args in: %s\ngot: %s",
+					usage, err.Error,
+				)
+			}
+		}
+	})
 
 	// A missing-caps placeholder after a flag must still be caught.
 	t.Run("single bare lowercase after flag is still caught", func(t *testing.T) {


### PR DESCRIPTION
`plugin validate` currently falsely reports a flag with a list of acceptable parameter values as an error, thinking the list is a placeholder for a single value:  

`Convert arguments values to CAPITAL letters (e.g., NAME, INSTANCE_ID, FORMAT).`

This PR provides for proper acceptance of this type of flag.