### PR TITLE
fix: handle multi-line usage

### DIFF
--- a/plugin/plugin_metadata_validator.go
+++ b/plugin/plugin_metadata_validator.go
@@ -589,7 +589,11 @@ func validatePositionalArguments(sl validator.StructLevel) {
 		return
 	}
 
-	usageText := cmd.Usage
+	// Only examine the first line of the usage string.
+	// Subsequent lines are often explanatory prose (e.g. "NAMESPACE is the name of
+	// the namespace to add.") and must not be scanned for lowercase argument tokens.
+	usageText := strings.SplitN(cmd.Usage, "\n", 2)[0]
+
 	// Check for lowercase positional argument values (should be CAPS)
 	// Look for lowercase words that appear to be user-input parameters
 	// Filter out common words, command names, and words that are part of the command structure

--- a/plugin/plugin_metadata_validator_usage_test.go
+++ b/plugin/plugin_metadata_validator_usage_test.go
@@ -1278,24 +1278,63 @@ func TestValidateUsageEnhanced_EdgeCases(t *testing.T) {
 				},
 			},
 			expectErrors: true, // Improved regex now catches this case
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-
-			pluginToErrors := validator.Errors(tc.pluginMetadata)
-
-			for _, errs := range pluginToErrors {
-				if tc.expectErrors {
-					assert.NotEmpty(t, errs, "Expected errors for: %s", tc.usage)
-				} else {
-					assert.Empty(t, errs, "Expected no errors for: %s", tc.usage)
+			},
+			{
+				name: "Multiline usage with explanatory continuation lines is not flagged",
+				pluginMetadata: []PluginMetadata{
+					{
+						Name: "cr",
+						Version: VersionType{
+							Major: 1,
+							Minor: 0,
+							Build: 0,
+						},
+						MinCliVersion: VersionType{
+							Major: 2,
+							Minor: 0,
+							Build: 0,
+						},
+						Namespaces: []Namespace{
+							{
+								ParentName: "",
+								Name:       "ibmcloud",
+							},
+						},
+						Commands: []Command{
+							{
+								Namespace:   "cr",
+								Name:        "namespace-add",
+								Description: "Add a namespace to your account.",
+								Usage:       "ibmcloud cr namespace-add [-g (RESOURCE_GROUP_NAME | RESOURCE_GROUP_ID)] NAMESPACE\nNAMESPACE is the name of the namespace to add. Do not put personal information in your namespace name.",
+								Flags: []Flag{
+									{
+										Name:        "g",
+										Description: "Optional: resource group name or ID.",
+									},
+								},
+							},
+						},
+					},
+				},
+				expectErrors: false,
+			},
+		}
+	
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+	
+				pluginToErrors := validator.Errors(tc.pluginMetadata)
+	
+				for _, errs := range pluginToErrors {
+					if tc.expectErrors {
+						assert.NotEmpty(t, errs, "Expected errors for: %s", tc.usage)
+					} else {
+						assert.Empty(t, errs, "Expected no errors for: %s", tc.usage)
+					}
 				}
-			}
-		})
+			})
+		}
 	}
-}
 
 // TestValidateUsageEnhanced_ErrorPriorities tests that errors have correct priorities
 func TestValidateUsageEnhanced_ErrorPriorities(t *testing.T) {


### PR DESCRIPTION
This PR updates the plug-in metadata validation to better process multi-line usage. The initial line should be the syntax, additional lines are for documentation purposes and not the command syntax.