### PR TITLE
fix: usage validation allow aliases

### DIFF
--- a/plugin/plugin_metadata_validator.go
+++ b/plugin/plugin_metadata_validator.go
@@ -653,17 +653,40 @@ func validatePositionalArguments(sl validator.StructLevel) {
 		"options": true, "arguments": true,
 	}
 
-	// Add words from the command name to exclusion list (these are command/subcommand names)
-	// Split on spaces but keep hyphenated words intact (e.g., "service-instance-create" stays as one word)
-	cmdWords := strings.Fields(cmd.Namespace + " " + cmd.Name)
-	for _, word := range cmdWords {
-		excludeWords[strings.ToLower(word)] = true
-		// Also exclude individual parts of hyphenated words (e.g., "list" and "all" from "list-all")
-		hyphenParts := strings.Split(word, "-")
-		for _, part := range hyphenParts {
+	// addExcludeToken adds a token and each of its hyphen-separated parts to the exclusion set.
+	// This ensures that "backup-now" (a command alias) excludes both "backup-now" and its
+	// individual parts "backup" and "now", just as command name parts are already excluded.
+	addExcludeToken := func(token string) {
+		token = strings.ToLower(token)
+		excludeWords[token] = true
+		for _, part := range strings.Split(token, "-") {
 			if part != "" {
-				excludeWords[strings.ToLower(part)] = true
+				excludeWords[part] = true
 			}
+		}
+	}
+
+	// Add words from the command name and namespace to exclusion list
+	for _, word := range strings.Fields(cmd.Namespace + " " + cmd.Name) {
+		addExcludeToken(word)
+	}
+
+	// Add command aliases (e.g., "backup-now" is an alias for "deployment-backup-now").
+	// These appear in usage strings alongside the primary command name and must not be
+	// flagged as lowercase argument placeholders.
+	if cmd.Alias != "" {
+		addExcludeToken(cmd.Alias)
+	}
+	for _, alias := range cmd.Aliases {
+		addExcludeToken(alias)
+	}
+
+	// Add plugin-level aliases (e.g., "cdb" for the "cloud-databases" plugin).
+	// Usage strings often include the short plugin alias as part of the invocation
+	// (e.g., "ibmcloud cdb backup-now NAME"), so they must be excluded too.
+	if top, ok := sl.Top().Interface().(PluginMetadata); ok {
+		for _, alias := range top.Aliases {
+			addExcludeToken(alias)
 		}
 	}
 

--- a/plugin/plugin_metadata_validator_usage_test.go
+++ b/plugin/plugin_metadata_validator_usage_test.go
@@ -845,6 +845,63 @@ func TestValidateUsageEnhanced_ExcludedWords(t *testing.T) {
 			},
 			shouldErr: false,
 		},
+		{
+			// Plugin aliases (e.g. "cdb" for "cloud-databases") appear in usage strings as
+			// part of the invocation shorthand. They must not be flagged as lowercase arguments.
+			name: "Plugin alias in usage is not flagged",
+			pluginMetadata: []PluginMetadata{
+				{
+					Name:    "cloud-databases",
+					Aliases: []string{"cdb"},
+					Version: VersionType{Major: 1},
+					MinCliVersion: VersionType{
+						Major: 2,
+					},
+					Namespaces: []Namespace{
+						{Name: "cloud-databases"},
+					},
+					Commands: []Command{
+						{
+							Namespace:   "cloud-databases",
+							Name:        "deployment-backups-list",
+							Description: "List backups for a deployment",
+							Usage:       "ibmcloud cdb deployment-backups-list NAME",
+							Flags:       []Flag{},
+						},
+					},
+				},
+			},
+			shouldErr: false,
+		},
+		{
+			// Command aliases (e.g. "backup-now" for "deployment-backup-now") also appear in
+			// usage strings and must not be flagged as lowercase arguments.
+			name: "Command alias in usage is not flagged",
+			pluginMetadata: []PluginMetadata{
+				{
+					Name:    "cloud-databases",
+					Aliases: []string{"cdb"},
+					Version: VersionType{Major: 1},
+					MinCliVersion: VersionType{
+						Major: 2,
+					},
+					Namespaces: []Namespace{
+						{Name: "cloud-databases"},
+					},
+					Commands: []Command{
+						{
+							Namespace:   "cloud-databases",
+							Name:        "deployment-backup-now",
+							Aliases:     []string{"backup-now"},
+							Description: "Trigger an immediate backup",
+							Usage:       "ibmcloud cdb backup-now NAME",
+							Flags:       []Flag{},
+						},
+					},
+				},
+			},
+			shouldErr: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR corrects the plug-in command usage validation to allow aliases for the plug-in namespace and commands to be used. 